### PR TITLE
fix(event): check all waves for event rewards

### DIFF
--- a/src/@types/events.ts
+++ b/src/@types/events.ts
@@ -1,6 +1,5 @@
 import type { BiomeId } from "#enums/biome-id";
 import type { EventType } from "#enums/event-type";
-import type { ClassicFixedBossWaves } from "#enums/fixed-boss-waves";
 import type { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import type { SpeciesId } from "#enums/species-id";
@@ -31,7 +30,6 @@ export interface EventMysteryEncounterTier {
 export interface EventWaveReward {
   /**
    * The wave at which the reward should be given.
-   * {@linkcode ClassicFixedBossWaves.RIVAL_1} and {@linkcode ClassicFixedBossWaves.RIVAL_2} are currently the only waves that give fixed rewards.
    */
   readonly wave: number;
   readonly type: ModifierTypeKeys;

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -58,36 +58,30 @@ export class VictoryPhase extends PokemonPhase {
         globalScene.phaseManager.pushNew("EggLapsePhase");
         if (gameMode.isClassic) {
           switch (currentWaveIndex) {
-            case ClassicFixedBossWaves.RIVAL_1:
-            case ClassicFixedBossWaves.RIVAL_2:
-            case ClassicFixedBossWaves.RIVAL_3:
-            case ClassicFixedBossWaves.RIVAL_4:
-            case ClassicFixedBossWaves.RIVAL_5:
-            case ClassicFixedBossWaves.RIVAL_6: {
-              // Get event modifiers for this wave
-              const fixedRewards = timedEventManager.getFixedBattleEventRewards(currentWaveIndex);
-
-              for (const fixedReward of fixedRewards) {
-                let reward = fixedReward;
-                const existingItem = globalScene.modifiers.find(m => m.type.id === reward);
-                if (existingItem && existingItem.getStackCount() + 1 > existingItem.getMaxStackCount()) {
-                  const tier = existingItem.type.getOrInferTier();
-                  if (!tier) {
-                    console.warn(`Modifier ${reward} is at max stacks but has no tier.`);
-                    break;
-                  }
-                  reward = `${ModifierTier[tier]}_BALL` as keyof typeof modifierTypes;
-                }
-                globalScene.phaseManager.pushNew("ModifierRewardPhase", modifierTypes[reward]);
-              }
-              break;
-            }
             case ClassicFixedBossWaves.EVIL_BOSS_2:
               // Should get Lock Capsule on 165 before shop phase so it can be used in the rewards shop
               globalScene.phaseManager.pushNew("ModifierRewardPhase", modifierTypes.LOCK_CAPSULE);
               break;
           }
+
+          // Get event modifiers for this wave
+          const fixedRewards = timedEventManager.getFixedBattleEventRewards(currentWaveIndex);
+
+          for (const fixedReward of fixedRewards) {
+            let reward = fixedReward;
+            const existingItem = globalScene.modifiers.find(m => m.type.id === reward);
+            if (existingItem && existingItem.getStackCount() + 1 > existingItem.getMaxStackCount()) {
+              const tier = existingItem.type.getOrInferTier();
+              if (!tier) {
+                console.warn(`Modifier ${reward} is at max stacks but has no tier.`);
+                break;
+              }
+              reward = `${ModifierTier[tier]}_BALL` as keyof typeof modifierTypes;
+            }
+            globalScene.phaseManager.pushNew("ModifierRewardPhase", modifierTypes[reward]);
+          }
         }
+
         if (currentWaveIndex % 10) {
           globalScene.phaseManager.pushNew(
             "SelectModifierPhase",


### PR DESCRIPTION
## What are the changes the user will see?
The current event will actually reward the event items on wave 115

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The game only checked on a handful of specifically specified waves if there were any fixed battle event rewards, but the event allows every wave to be specified. This means you have to always check two places in order to add a battle reward and its not very friendly to balance making events. Makes more sense to just check every wave and don't limit the event deep in the code.

## What are the changes from a developer perspective?
`getFixedBattleEventRewards` runs on every classic wave now instead on only ~6 waves, I don't expect an impact on performance as it only does a get event and filter on waves in the event.

## Screenshots/Videos


## How to test the changes?
```ts
const overrides = {
  STARTING_LEVEL_OVERRIDE: 9999,
  STARTING_WAVE_OVERRIDE: 115,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
