### PR TITLE
fix(beta): trying to rebind keys won't crash the game

### DIFF
--- a/src/ui/handlers/base-binding-ui-handler.ts
+++ b/src/ui/handlers/base-binding-ui-handler.ts
@@ -46,7 +46,7 @@ export abstract class BaseBindingUiHandler extends UiHandler {
 
   // The specific setting being modified.
   protected target;
-  protected tabMenu: TabMenu;
+  protected tabMenu: TabMenu | undefined;
 
   constructor(mode: UiMode | null = null) {
     super(mode);
@@ -190,7 +190,7 @@ export abstract class BaseBindingUiHandler extends UiHandler {
           this.cancelFn?.();
         } else {
           success = this.swapAction();
-          this.tabMenu.updateIcons();
+          this.tabMenu?.updateIcons();
           this.cancelFn?.(success);
         }
         break;


### PR DESCRIPTION
## What are the changes the user will see?
Trying to rebind a key will no longer crash the game.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing a bug.

## What are the changes from a developer perspective?
Added a missing optional chaining operator and corrected the type of `BaseBindingUiHandler#tabMenu` to include `| undefined`.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually