### PR TITLE
github: depcruise step of linting workflow now ignores scripts

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -74,9 +74,7 @@ jobs:
             (
               needs.linting-path-filter.outputs.all == 'true' ||
               needs.linting-path-filter.outputs.ts-files == 'true' ||
-              needs.linting-path-filter.outputs.js-files == 'true' ||
-              needs.linting-path-filter.outputs.github-scripts == 'true' ||
-              needs.linting-path-filter.outputs.local-scripts == 'true'
+              needs.linting-path-filter.outputs.js-files == 'true'
             ) }}
 
       # Validate dependencies with dependency-cruiser - https://github.com/sverweij/dependency-cruiser

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "biome:all": "biome check --write --no-errors-on-unmatched --diagnostic-level=error",
     "biome:ci": "biome ci --diagnostic-level=error --reporter=github --reporter=default --no-errors-on-unmatched",
     "typedoc": "typedoc",
-    "depcruise": "depcruise src test",
+    "depcruise": "depcruise src test plugins/phaser plugins/vite",
     "postinstall": "lefthook install; git config --local fetch.recurseSubmodules true; git config --local blame.ignoreRevsFile .git-blame-ignore-revs",
     "update-locales": "pnpm update-submodules locales",
     "update-locales:remote": "pnpm update-submodules:remote locales",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The way we have Dependency Cruiser configured, it doesn't process the local or GitHub scripts files (and it would emit spurious errors if it did), so it doesn't make sense for the workflow to check for changes to those files in order to run.

## What are the changes from a developer perspective?
Removed the checks for changes to script files in order to determine if the depcruise workflow step should run.
Also updated the `pnpm depcruise` command to check the `plugins/phaser` and `plugins/vite` directories due to the files in those directories having been moved out of `src` earlier.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually