### PR TITLE
refactor: clean up various weather/terrain message & anim funcs

### DIFF
--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -1,4 +1,5 @@
 import { getPokemonNameWithAffix } from "#app/messages";
+import { CommonAnim } from "#enums/move-anims-common";
 import type { Pokemon } from "#field/pokemon";
 import type { RGBArray } from "#types/sprite-types";
 import i18next from "i18next";
@@ -17,9 +18,9 @@ export interface SerializedTerrain {
 }
 
 export class Terrain {
-  public terrainType: TerrainType;
+  public readonly terrainType: TerrainType;
   public turnsLeft: number;
-  public maxDuration: number;
+  public readonly maxDuration: number;
 
   constructor(terrainType: TerrainType, turnsLeft = 0, maxDuration: number = turnsLeft) {
     this.terrainType = terrainType;
@@ -51,9 +52,9 @@ export function getTerrainName(terrainType: TerrainType): string {
       return i18next.t("terrain:grassy");
     case TerrainType.PSYCHIC:
       return i18next.t("terrain:psychic");
+    case TerrainType.NONE:
+      return "";
   }
-
-  return "";
 }
 
 export function getTerrainColor(terrainType: TerrainType): RGBArray {
@@ -66,9 +67,9 @@ export function getTerrainColor(terrainType: TerrainType): RGBArray {
       return [120, 200, 80];
     case TerrainType.PSYCHIC:
       return [160, 64, 160];
+    case TerrainType.NONE:
+      return [0, 0, 0];
   }
-
-  return [0, 0, 0];
 }
 
 /**
@@ -87,9 +88,6 @@ export function getTerrainStartMessage(terrainType: TerrainType): string {
     case TerrainType.PSYCHIC:
       return i18next.t("terrain:psychicStartMessage");
     case TerrainType.NONE:
-    default:
-      terrainType satisfies TerrainType.NONE;
-      console.warn(`${terrainType} unexpectedly provided as terrain type to getTerrainStartMessage!`);
       return "";
   }
 }
@@ -110,9 +108,6 @@ export function getTerrainClearMessage(terrainType: TerrainType): string {
     case TerrainType.PSYCHIC:
       return i18next.t("terrain:psychicClearMessage");
     case TerrainType.NONE:
-    default:
-      terrainType satisfies TerrainType.NONE;
-      console.warn(`${terrainType} unexpectedly provided as terrain type to getTerrainClearMessage!`);
       return "";
   }
 }
@@ -137,9 +132,15 @@ export function getTerrainBlockMessage(pokemon: Pokemon, terrainType: TerrainTyp
         terrainName: getTerrainName(terrainType),
       });
     case TerrainType.NONE:
-    default:
-      terrainType satisfies TerrainType.NONE;
-      console.warn(`${terrainType} unexpectedly provided as terrain type to getTerrainBlockMessage!`);
       return "";
   }
+}
+
+/**
+ * Gets the animation associated with the given terrain type
+ * @param terrainType - The {@linkcode TerrainType} to get the animiation for
+ * @returns The {@linkcode CommonAnim} for the given terrain
+ */
+export function getTerrainAnim(terrainType: TerrainType): CommonAnim {
+  return (CommonAnim.MISTY_TERRAIN + (terrainType - 1)) as CommonAnim;
 }

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -2,6 +2,7 @@ import type { PreAttackWeatherOverrideAbAttr, SuppressWeatherEffectAbAttr } from
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { CommonAnim } from "#enums/move-anims-common";
 import { PokemonType } from "#enums/pokemon-type";
 import { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
@@ -16,9 +17,9 @@ export interface SerializedWeather {
 
 export class Weather {
   // TODO: Exclude `WeatherType.NONE` from this (which indicates a lack of weather)
-  public weatherType: WeatherType;
+  public readonly weatherType: WeatherType;
   public turnsLeft: number;
-  public maxDuration: number;
+  public readonly maxDuration: number;
 
   constructor(weatherType: WeatherType, turnsLeft = 0, maxDuration: number = turnsLeft) {
     this.weatherType = weatherType;
@@ -108,9 +109,7 @@ export class Weather {
   }
 }
 
-// TODO: These functions should not be able to accept `WeatherType.NONE`
-// and should have `null` removed from the signature
-export function getWeatherStartMessage(weatherType: WeatherType): string | null {
+export function getWeatherStartMessage(weatherType: WeatherType): string {
   switch (weatherType) {
     case WeatherType.SUNNY:
       return i18next.t("weather:sunnyStartMessage");
@@ -130,12 +129,12 @@ export function getWeatherStartMessage(weatherType: WeatherType): string | null 
       return i18next.t("weather:harshSunStartMessage");
     case WeatherType.STRONG_WINDS:
       return i18next.t("weather:strongWindsStartMessage");
+    case WeatherType.NONE:
+      return "";
   }
-
-  return null;
 }
 
-export function getWeatherLapseMessage(weatherType: WeatherType): string | null {
+export function getWeatherLapseMessage(weatherType: WeatherType): string {
   switch (weatherType) {
     case WeatherType.SUNNY:
       return i18next.t("weather:sunnyLapseMessage");
@@ -155,12 +154,12 @@ export function getWeatherLapseMessage(weatherType: WeatherType): string | null 
       return i18next.t("weather:harshSunLapseMessage");
     case WeatherType.STRONG_WINDS:
       return i18next.t("weather:strongWindsLapseMessage");
+    case WeatherType.NONE:
+      return "";
   }
-
-  return null;
 }
 
-export function getWeatherDamageMessage(weatherType: WeatherType, pokemon: Pokemon): string | null {
+export function getWeatherDamageMessage(weatherType: WeatherType, pokemon: Pokemon): string {
   switch (weatherType) {
     case WeatherType.SANDSTORM:
       return i18next.t("weather:sandstormDamageMessage", {
@@ -172,10 +171,10 @@ export function getWeatherDamageMessage(weatherType: WeatherType, pokemon: Pokem
       });
   }
 
-  return null;
+  return "";
 }
 
-export function getWeatherClearMessage(weatherType: WeatherType): string | null {
+export function getWeatherClearMessage(weatherType: WeatherType): string {
   switch (weatherType) {
     case WeatherType.SUNNY:
       return i18next.t("weather:sunnyClearMessage");
@@ -195,12 +194,12 @@ export function getWeatherClearMessage(weatherType: WeatherType): string | null 
       return i18next.t("weather:harshSunClearMessage");
     case WeatherType.STRONG_WINDS:
       return i18next.t("weather:strongWindsClearMessage");
+    case WeatherType.NONE:
+      return "";
   }
-
-  return null;
 }
 
-export function getLegendaryWeatherContinuesMessage(weatherType: WeatherType): string | null {
+export function getLegendaryWeatherContinuesMessage(weatherType: WeatherType): string {
   switch (weatherType) {
     case WeatherType.HARSH_SUN:
       return i18next.t("weather:harshSunContinueMessage");
@@ -209,7 +208,8 @@ export function getLegendaryWeatherContinuesMessage(weatherType: WeatherType): s
     case WeatherType.STRONG_WINDS:
       return i18next.t("weather:strongWindsContinueMessage");
   }
-  return null;
+
+  return "";
 }
 
 export function getWeatherBlockMessage(weatherType: WeatherType): string {
@@ -219,6 +219,7 @@ export function getWeatherBlockMessage(weatherType: WeatherType): string {
     case WeatherType.HEAVY_RAIN:
       return i18next.t("weather:heavyRainEffectMessage");
   }
+
   return i18next.t("weather:defaultEffectMessage");
 }
 
@@ -246,6 +247,7 @@ export function getEffectiveWeatherForMove(user: Pokemon): WeatherType {
   if (!weather || weather.isEffectSuppressed()) {
     return WeatherType.NONE;
   }
+
   return weather.weatherType;
 }
 
@@ -288,4 +290,13 @@ export function getWeatherMultiplierForMove(user: Pokemon, move: Move): number {
   }
 
   return 1;
+}
+
+/**
+ * Gets the animation associated with the given weather type
+ * @param weatherType - The {@linkcode WeatherType} to get the animiation for
+ * @returns The {@linkcode CommonAnim} for the given weather
+ */
+export function getWeatherAnim(weatherType: WeatherType): CommonAnim {
+  return (CommonAnim.SUNNY + (weatherType - 1)) as CommonAnim;
 }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -13,9 +13,10 @@ import { SpeciesFormChangeRevertWeatherFormTrigger, SpeciesFormChangeWeatherTrig
 import type { PokemonSpecies } from "#data/pokemon-species";
 import type { PositionalTag } from "#data/positional-tags/positional-tag";
 import { PositionalTagManager } from "#data/positional-tags/positional-tag-manager";
-import { getTerrainClearMessage, getTerrainStartMessage, Terrain, TerrainType } from "#data/terrain";
+import { getTerrainAnim, getTerrainClearMessage, getTerrainStartMessage, Terrain, TerrainType } from "#data/terrain";
 import {
   getLegendaryWeatherContinuesMessage,
+  getWeatherAnim,
   getWeatherClearMessage,
   getWeatherStartMessage,
   Weather,
@@ -26,7 +27,6 @@ import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { BattlerIndex } from "#enums/battler-index";
 import { BiomeId } from "#enums/biome-id";
 import { BiomePoolTier } from "#enums/biome-pool-tier";
-import { CommonAnim } from "#enums/move-anims-common";
 import type { MoveId } from "#enums/move-id";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
@@ -254,8 +254,8 @@ export class Arena {
     this.weather = new Weather(weather, 0);
 
     this.eventTarget.dispatchEvent(new WeatherChangedEvent(weather, 0));
-    globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, CommonAnim.SUNNY + (weather - 1));
-    globalScene.phaseManager.queueMessage(getWeatherStartMessage(weather)!); // TODO: is this bang correct?
+    globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, getWeatherAnim(weather));
+    globalScene.phaseManager.queueMessage(getWeatherStartMessage(weather));
   }
 
   /**
@@ -280,13 +280,8 @@ export class Arena {
       this.weather?.isImmutable()
       && ![WeatherType.HARSH_SUN, WeatherType.HEAVY_RAIN, WeatherType.STRONG_WINDS, WeatherType.NONE].includes(weather)
     ) {
-      globalScene.phaseManager.unshiftNew(
-        "CommonAnimPhase",
-        undefined,
-        undefined,
-        CommonAnim.SUNNY + (oldWeatherType - 1),
-      );
-      globalScene.phaseManager.queueMessage(getLegendaryWeatherContinuesMessage(oldWeatherType)!);
+      globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, getWeatherAnim(oldWeatherType));
+      globalScene.phaseManager.queueMessage(getLegendaryWeatherContinuesMessage(oldWeatherType));
       return false;
     }
 
@@ -300,13 +295,13 @@ export class Arena {
     if (weather === WeatherType.NONE) {
       this.weather = null;
       this.eventTarget.dispatchEvent(new WeatherChangedEvent(WeatherType.NONE));
-      globalScene.phaseManager.queueMessage(getWeatherClearMessage(oldWeatherType)!); // TODO: is this bang correct?
+      globalScene.phaseManager.queueMessage(getWeatherClearMessage(oldWeatherType));
     } else {
       this.weather = new Weather(weather, weatherDuration.value, weatherDuration.value);
       this.eventTarget.dispatchEvent(new WeatherChangedEvent(weather, weatherDuration.value));
 
-      globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, CommonAnim.SUNNY + (weather - 1));
-      globalScene.phaseManager.queueMessage(getWeatherStartMessage(weather)!); // TODO: is this bang correct?
+      globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, getWeatherAnim(weather));
+      globalScene.phaseManager.queueMessage(getWeatherStartMessage(weather));
     }
 
     for (const pokemon of inSpeedOrder(ArenaTagSide.BOTH)) {
@@ -430,12 +425,7 @@ export class Arena {
       this.terrain = new Terrain(terrain, terrainDuration.value, terrainDuration.value);
       this.eventTarget.dispatchEvent(new TerrainChangedEvent(terrain, terrainDuration.value));
       if (!ignoreAnim) {
-        globalScene.phaseManager.unshiftNew(
-          "CommonAnimPhase",
-          undefined,
-          undefined,
-          CommonAnim.MISTY_TERRAIN + (terrain - 1),
-        );
+        globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, getTerrainAnim(terrain));
       }
       globalScene.phaseManager.queueMessage(getTerrainStartMessage(terrain));
     }
@@ -457,13 +447,8 @@ export class Arena {
     // TODO: Add a flag for permanent terrains
     this.terrain = new Terrain(terrain, 0);
     this.eventTarget.dispatchEvent(new TerrainChangedEvent(terrain, this.terrain.turnsLeft));
-    globalScene.phaseManager.unshiftNew(
-      "CommonAnimPhase",
-      undefined,
-      undefined,
-      CommonAnim.MISTY_TERRAIN + (terrain - 1),
-    );
-    globalScene.phaseManager.queueMessage(getTerrainStartMessage(terrain) ?? ""); // TODO: Remove `?? ""` when terrain-fail-msg branch removes `null` from these signatures
+    globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, getTerrainAnim(terrain));
+    globalScene.phaseManager.queueMessage(getTerrainStartMessage(terrain));
   }
 
   /** Sets a random terrain based on the biome */

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -1,50 +1,52 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import type { Weather } from "#data/weather";
-import { getWeatherDamageMessage, getWeatherLapseMessage } from "#data/weather";
+import { getWeatherAnim, getWeatherDamageMessage, getWeatherLapseMessage } from "#data/weather";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { HitResult } from "#enums/hit-result";
-import { CommonAnim } from "#enums/move-anims-common";
-import { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
 import { CommonAnimPhase } from "#phases/common-anim-phase";
-import { BooleanHolder, toDmgValue } from "#utils/common";
+import { toDmgValue } from "#utils/common";
+import { ValueHolder } from "#utils/value-holder";
 
 export class WeatherEffectPhase extends CommonAnimPhase {
   public readonly phaseName = "WeatherEffectPhase";
+
+  // TODO: is this field even necessary? it's immediately updated in `start()`
+  // so the stored value from the constructor is never used
   public weather: Weather | null;
 
   constructor() {
-    super(
-      undefined,
-      undefined,
-      CommonAnim.SUNNY + ((globalScene?.arena?.weather?.weatherType || WeatherType.NONE) - 1),
-    );
-    this.weather = globalScene?.arena?.weather;
+    super(undefined, undefined, getWeatherAnim(globalScene.arena.weatherType));
+
+    this.weather = globalScene.arena.weather;
   }
 
-  start() {
+  public override start(): void {
     // Update weather state with any changes that occurred during the turn
-    this.weather = globalScene?.arena?.weather;
+    this.weather = globalScene.arena.weather;
+    // buffer const used so TS actually understands the `null` guard
+    const weather = this.weather;
 
-    if (!this.weather) {
-      return this.end();
+    if (!weather) {
+      this.end();
+      return;
     }
 
-    this.setAnimation(CommonAnim.SUNNY + (this.weather.weatherType - 1));
+    this.setAnimation(getWeatherAnim(weather.weatherType));
 
-    if (this.weather.isDamaging()) {
-      const cancelled = new BooleanHolder(false);
+    if (weather.isDamaging()) {
+      const suppressed = new ValueHolder(false);
 
       this.executeForAll((pokemon: Pokemon) =>
-        applyAbAttrs("SuppressWeatherEffectAbAttr", { pokemon, weather: this.weather, cancelled }),
+        applyAbAttrs("SuppressWeatherEffectAbAttr", { pokemon, weather, cancelled: suppressed }),
       );
 
-      if (!cancelled.value) {
+      if (!suppressed.value) {
         const inflictDamage = (pokemon: Pokemon) => {
-          const cancelled = new BooleanHolder(false);
+          const cancelled = new ValueHolder(false);
 
-          applyAbAttrs("PreWeatherDamageAbAttr", { pokemon, weather: this.weather, cancelled });
+          applyAbAttrs("PreWeatherDamageAbAttr", { pokemon, weather, cancelled });
           applyAbAttrs("BlockNonDirectDamageAbAttr", { pokemon, cancelled });
 
           if (
@@ -57,14 +59,14 @@ export class WeatherEffectPhase extends CommonAnimPhase {
 
           const damage = toDmgValue(pokemon.getMaxHp() / 16);
 
-          globalScene.phaseManager.queueMessage(getWeatherDamageMessage(this.weather!.weatherType, pokemon) ?? "");
+          globalScene.phaseManager.queueMessage(getWeatherDamageMessage(weather.weatherType, pokemon));
           pokemon.damageAndUpdate(damage, { result: HitResult.INDIRECT, ignoreSegments: true });
         };
 
         this.executeForAll((pokemon: Pokemon) => {
           const immune =
             !pokemon
-            || pokemon.getTypes({ returnOriginalTypesIfStellar: true }).filter(t => this.weather?.isTypeDamageImmune(t))
+            || pokemon.getTypes({ returnOriginalTypesIfStellar: true }).filter(t => weather.isTypeDamageImmune(t))
               .length > 0
             || pokemon.switchOutStatus;
           if (!immune) {
@@ -74,10 +76,10 @@ export class WeatherEffectPhase extends CommonAnimPhase {
       }
     }
 
-    globalScene.ui.showText(getWeatherLapseMessage(this.weather.weatherType) ?? "", null, () => {
+    globalScene.ui.showText(getWeatherLapseMessage(weather.weatherType), null, () => {
       this.executeForAll((pokemon: Pokemon) => {
         if (!pokemon.switchOutStatus) {
-          applyAbAttrs("PostWeatherLapseAbAttr", { pokemon, weather: this.weather });
+          applyAbAttrs("PostWeatherLapseAbAttr", { pokemon, weather });
         }
       });
 

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -1,6 +1,5 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
-import type { Weather } from "#data/weather";
 import { getWeatherAnim, getWeatherDamageMessage, getWeatherLapseMessage } from "#data/weather";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { HitResult } from "#enums/hit-result";
@@ -12,21 +11,12 @@ import { ValueHolder } from "#utils/value-holder";
 export class WeatherEffectPhase extends CommonAnimPhase {
   public readonly phaseName = "WeatherEffectPhase";
 
-  // TODO: is this field even necessary? it's immediately updated in `start()`
-  // so the stored value from the constructor is never used
-  public weather: Weather | null;
-
   constructor() {
     super(undefined, undefined, getWeatherAnim(globalScene.arena.weatherType));
-
-    this.weather = globalScene.arena.weather;
   }
 
   public override start(): void {
-    // Update weather state with any changes that occurred during the turn
-    this.weather = globalScene.arena.weather;
-    // buffer const used so TS actually understands the `null` guard
-    const weather = this.weather;
+    const weather = globalScene.arena.weather;
 
     if (!weather) {
       this.end();


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Cleaning up some code.

## What are the changes from a developer perspective?
- Removed `null` as a possible return value from some weather message functions and updated the callsites.
- Added and implemented `get[Terrain|Weather]Anim` utility functions.
- Marked `Weather#weatherType`, `[Weather|Terrain]#maxDuration` and `Terrain#terrainType` as `readonly`.
- Removed redundant `WeatherEffectPhase#weather` field.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR