### PR TITLE
refactor: clean up some move-related methods in `Pokemon`

### DIFF
--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -85,7 +85,12 @@ function getAndWeightLevelMoves(pokemon: Pokemon): Map<MoveId, number> {
   let allLevelMoves: LevelMovesWithSource;
   // TODO: Investigate why there needs to be error handling here
   try {
-    allLevelMoves = pokemon.getLevelMoves(1, true, true, pokemon.hasTrainer());
+    allLevelMoves = pokemon.getLevelMoves({
+      startingLevel: 1,
+      includeEvolutionMoves: true,
+      includePrevolutionMoves: true,
+      includeRelearnerMoves: pokemon.hasTrainer(),
+    });
   } catch (e) {
     console.warn("Error encountered trying to generate moveset for %s: %s", pokemon.species.name, e);
     return movePool;

--- a/src/data/balance/moves/egg-moves.ts
+++ b/src/data/balance/moves/egg-moves.ts
@@ -593,4 +593,4 @@ export const speciesEggMoves = {
   [SpeciesId.PALDEA_TAUROS]: [ MoveId.U_TURN, MoveId.SUCKER_PUNCH, MoveId.HORN_LEECH, MoveId.THUNDEROUS_KICK ],
   [SpeciesId.PALDEA_WOOPER]: [ MoveId.STONE_AXE, MoveId.RECOVER, MoveId.BANEFUL_BUNKER, MoveId.BARB_BARRAGE ],
   [SpeciesId.BLOODMOON_URSALUNA]: [ MoveId.NASTY_PLOT, MoveId.ROCK_POLISH, MoveId.SANDSEAR_STORM, MoveId.BOOMBURST ]
-} satisfies Partial<Record<SpeciesId, [MoveId, MoveId, MoveId, MoveId]>>;
+} as const satisfies Partial<Record<SpeciesId, [MoveId, MoveId, MoveId, MoveId]>>;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -190,6 +190,8 @@ import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import type { NonEmptyTuple } from "type-fest";
 import { getBaseLearnableMoveSource, getLevelMoves } from "./learnsets";
 
+type LearnableLevelMoves = [level: number | null, move: MoveId, source: LearnableMoveSource][];
+
 export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * This pokemon's {@link https://bulbapedia.bulbagarden.net/wiki/Personality_value | Personality value/PID},
@@ -307,14 +309,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * The set of all TMs that have been used on this Pokémon
    *
    * @remarks
-   * Used to allow re-learning TM moves via, e.g., the Memory Mushroom
+   * Used to allow re-learning TM moves (e.g. via the Memory Mushroom)
    */
-  public usedTMs: MoveId[];
+  // TODO: move into `PlayerPokemon`
+  public usedTMs: MoveId[] = [];
 
   private shinySparkle: Phaser.GameObjects.Sprite;
 
   /** Stat stages queued by berry eating to be run in a single phase */
-  public queuedBerryStatChanges: Mutable<StatChange>[] = []; // todo Doing it this way to touch modifiers as little as possible, may not be ideal permanent solution
+  // TODO: Doing it this way to touch modifiers as little as possible, may not be ideal permanent solution
+  public queuedBerryStatChanges: Mutable<StatChange>[] = [];
 
   // TODO: Rework this eventually
   constructor(
@@ -1863,13 +1867,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   abstract isBoss(): boolean;
 
+  // #region Moves/Moveset
+
   /**
    * Return all the {@linkcode PokemonMove}s that make up this Pokemon's moveset.
+   * @remarks
    * Takes into account player/enemy moveset overrides (which will also override PP count).
    * @param ignoreOverride - Whether to ignore any overrides caused by {@linkcode MoveId.TRANSFORM | Transform}; default `false`
    * @returns An array of {@linkcode PokemonMove}, as described above.
    */
-  getMoveset(ignoreOverride = false): PokemonMove[] {
+  public getMoveset(ignoreOverride = false): PokemonMove[] {
     // Override moveset based on arrays specified in overrides.ts
     const overrideArray = coerceArray(
       this.isPlayer() ? activeOverrides.MOVESET_OVERRIDE : activeOverrides.ENEMY_MOVESET_OVERRIDE,
@@ -1892,14 +1899,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Check which egg moves have been unlocked for this {@linkcode Pokemon}.
+   * @remarks
    * Looks at either the species it was met at or the first {@linkcode Species} in its evolution
    * line that can act as a starter and provides those egg moves.
    * @returns An array of all {@linkcode MoveId}s that are egg moves and unlocked for this Pokemon.
    */
-  getUnlockedEggMoves(): MoveId[] {
+  private getUnlockedEggMoves(): MoveId[] {
     const moves: MoveId[] = [];
     const species =
       this.metSpecies in speciesEggMoves ? this.metSpecies : this.getSpeciesForm(true).getRootSpeciesId(true);
+
     if (species in speciesEggMoves) {
       for (let i = 0; i < 4; i++) {
         if (globalScene.gameData.starterData[species].eggMoves & (1 << i)) {
@@ -1907,6 +1916,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         }
       }
     }
+
     return moves;
   }
 
@@ -1918,26 +1928,24 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * in the starting party of the run and if Fresh Start is not active.
    * @returns A tuple of the Level (or `null` for non level moves), {@linkcode MoveId} and their corresponding {@linkcode LearnableMoveSource}, as described above.
    */
-  // TODO: move into `#region LevelMoves`
-  public getLearnableLevelMoves(): [number | null, MoveId, LearnableMoveSource][] {
-    let learnableMoves: [number | null, MoveId, LearnableMoveSource][] = [];
-    learnableMoves = this.getLevelMoves(1, true, true, true);
+  public getLearnableLevelMoves(): LearnableLevelMoves {
+    let learnableMoves: LearnableLevelMoves = this.getLevelMoves({
+      startingLevel: 1,
+      includeEvolutionMoves: true,
+      includePrevolutionMoves: true,
+      includeRelearnerMoves: true,
+    });
+
     if (this.metBiome === -1 && !globalScene.gameMode.isFreshStartChallenge() && !globalScene.gameMode.isDaily) {
-      const eggMoves: [number | null, MoveId, LearnableMoveSource][] = this.getUnlockedEggMoves().map(em => [
-        null,
-        em,
-        LearnableMoveSource.EGG,
-      ]);
+      const eggMoves: LearnableLevelMoves = this.getUnlockedEggMoves().map(em => [null, em, LearnableMoveSource.EGG]);
       learnableMoves.push(...eggMoves);
     }
-    if (Array.isArray(this.usedTMs) && this.usedTMs.length > 0) {
-      const tmMoves: [number | null, MoveId, LearnableMoveSource][] = this.usedTMs.map(tm => [
-        null,
-        tm,
-        LearnableMoveSource.TM,
-      ]);
+
+    if (this.usedTMs.length > 0) {
+      const tmMoves: LearnableLevelMoves = this.usedTMs.map(tm => [null, tm, LearnableMoveSource.TM]);
       learnableMoves.push(...tmMoves.filter(tm => !learnableMoves.some(lm => lm[1] === tm[1])));
     }
+
     learnableMoves = learnableMoves.filter(lm => !this.moveset.some(m => m.moveId === lm[1]));
 
     // Sort by source in descending order, so the moves with a species prefix will be at the top
@@ -1949,6 +1957,62 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     return learnableMoves;
   }
+
+  /**
+   * Get all level up moves in a given range for a particular pokemon.
+   * @param startingLevel - (Default `this.level`) Don't include moves below this level
+   * @param includeEvolutionMoves - (Default `false`) Whether to include evolution moves
+   * @param includePrevolutionMoves - (Default `false`) Whether to include moves from prior evolutions
+   * @param includeRelearnerMoves - (Default `false`) Whether to include moves that would require a relearner. Note the move relearner inherently allows evolution moves
+   * @param learnSituation - (Default {@linkcode LearnMoveSituation.MISC}) The type of moves to get (e.g. level up, relearn, etc)
+   * @returns A list of moves and the levels they can be learned at, along with the source of the move
+   */
+  public getLevelMoves({
+    startingLevel = this.level,
+    includeEvolutionMoves = false,
+    includePrevolutionMoves = false,
+    includeRelearnerMoves = false,
+    learnSituation = LearnMoveSituation.MISC,
+  }: {
+    startingLevel?: number;
+    includeEvolutionMoves?: boolean;
+    includePrevolutionMoves?: boolean;
+    includeRelearnerMoves?: boolean;
+    learnSituation?: LearnMoveSituation;
+  } = {}): LevelMovesWithSource {
+    return getLevelMoves(
+      this,
+      startingLevel,
+      includeEvolutionMoves,
+      includePrevolutionMoves,
+      includeRelearnerMoves,
+      learnSituation,
+    );
+  }
+
+  /** @returns A list of this Pokemon's possible egg moves */
+  // TODO: remove `| undefined` once regular Pikachu is no longer a starter
+  public getEggMoves(): MoveId[] | undefined {
+    return speciesEggMoves[this.getSpeciesForm().getRootSpeciesId()];
+  }
+
+  /**
+   * Create a new {@linkcode PokemonMove} and set it to the specified move index in this Pokémon's moveset.
+   * @param moveIndex - The index of the move to set
+   * @param moveId - The ID of the move to set
+   */
+  public setMove(moveIndex: number, moveId: MoveId): void {
+    if (moveId === MoveId.NONE) {
+      return;
+    }
+    const move = new PokemonMove(moveId);
+    this.moveset[moveIndex] = move;
+    if (this.summonData.moveset) {
+      this.summonData.moveset[moveIndex] = move;
+    }
+  }
+
+  // #endregion Moves/Moveset
 
   /**
    * Evaluate and return this Pokemon's typing.
@@ -2790,63 +2854,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     return null;
-  }
-
-  //#region LevelMoves
-
-  /**
-   * Get all level up moves in a given range for a particular pokemon.
-   * @param startingLevel - Don't include moves below this level
-   * @param includeEvolutionMoves - Whether to include evolution moves
-   * @param includePrevolutionMoves - Whether to include moves from prior evolutions
-   * @param includeRelearnerMoves - Whether to include moves that would require a relearner. Note the move relearner inherently allows evolution moves
-   * @returns A list of moves and the levels they can be learned at, along with the source of the move
-   */
-  // TODO: convert to use object param
-  public getLevelMoves(
-    startingLevel?: number,
-    includeEvolutionMoves = false,
-    includePrevolutionMoves = false,
-    includeRelearnerMoves = false,
-    learnSituation: LearnMoveSituation = LearnMoveSituation.MISC,
-  ): LevelMovesWithSource {
-    if (!startingLevel) {
-      startingLevel = this.level;
-    }
-    return getLevelMoves(
-      this,
-      startingLevel,
-      includeEvolutionMoves,
-      includePrevolutionMoves,
-      includeRelearnerMoves,
-      learnSituation,
-    );
-  }
-
-  //#endregion LevelMoves
-
-  /**
-   * Get a list of all egg moves
-   * @returns list of egg moves
-   */
-  getEggMoves(): MoveId[] | undefined {
-    return speciesEggMoves[this.getSpeciesForm().getRootSpeciesId()];
-  }
-
-  /**
-   * Create a new {@linkcode PokemonMove} and set it to the specified move index in this Pokémon's moveset.
-   * @param moveIndex - The index of the move to set
-   * @param moveId - The ID of the move to set
-   */
-  setMove(moveIndex: number, moveId: MoveId): void {
-    if (moveId === MoveId.NONE) {
-      return;
-    }
-    const move = new PokemonMove(moveId);
-    this.moveset[moveIndex] = move;
-    if (this.summonData.moveset) {
-      this.summonData.moveset[moveIndex] = move;
-    }
   }
 
   /**
@@ -5855,8 +5862,9 @@ export class PlayerPokemon extends Pokemon {
    * Get all TMs compatible with this Pokémon. Includes TMs from its fused species.
    * @returns An array of all compatible TMs
    */
-  getCompatibleTms(excludeKnown = false, excludeLevelUp = false, excludeUsedTMs = false): MoveId[] {
+  public getCompatibleTms(excludeKnown = false, excludeLevelUp = false, excludeUsedTMs = false): MoveId[] {
     const tms = new Set(this.species.getTms(this.getFormKey()));
+
     if (this.fusionSpecies) {
       this.fusionSpecies.getTms(this.getFusionFormKey() ?? undefined).forEach(tm => tms.add(tm));
     }
@@ -5864,10 +5872,10 @@ export class PlayerPokemon extends Pokemon {
       this.moveset.forEach(move => tms.delete(move.moveId));
     }
     if (excludeLevelUp) {
-      this.getLevelMoves(undefined, true, false, true).forEach(lm => tms.delete(lm[1]));
+      this.getLevelMoves({ includeEvolutionMoves: true, includeRelearnerMoves: true }).forEach(lm => tms.delete(lm[1]));
     }
     if (excludeUsedTMs) {
-      this.usedTMs?.forEach(moveId => tms.delete(moveId));
+      this.usedTMs.forEach(moveId => tms.delete(moveId));
     }
 
     return Array.from(tms);
@@ -5879,7 +5887,7 @@ export class PlayerPokemon extends Pokemon {
    * @param excludeKnown - (Default `false`) Whether to exclude TMs or moves this Pokémon already knows
    * @returns Whether this TM is compatible with this Pokémon
    */
-  isTmCompatible(tm: MoveId, excludeKnown = false): boolean {
+  public isTmCompatible(tm: MoveId, excludeKnown = false): boolean {
     return this.getCompatibleTms(excludeKnown).includes(tm);
   }
 

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -403,7 +403,7 @@ export class EvolutionPhase extends Phase {
         ? LearnMoveSituation.EVOLUTION_FUSED_BASE
         : LearnMoveSituation.EVOLUTION;
     const levelMoves = this.pokemon
-      .getLevelMoves(this.lastLevel + 1, true, false, false, learnSituation)
+      .getLevelMoves({ startingLevel: this.lastLevel + 1, includeEvolutionMoves: true, learnSituation })
       .filter(lm => lm[0] === EVOLVE_MOVE);
     for (const lm of levelMoves) {
       globalScene.phaseManager.unshiftNew("LearnMovePhase", globalScene.getPlayerParty().indexOf(this.pokemon), lm[1]);

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -17,6 +17,7 @@ import i18next from "i18next";
 
 export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
   public readonly phaseName = "LearnMovePhase";
+
   private readonly moveId: MoveId;
   private messageMode: UiMode;
   private readonly learnMoveType: LearnMoveType;
@@ -72,7 +73,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    * @param move The Move to be learned
    * @param Pokemon The Pokemon learning the move
    */
-  async replaceMoveCheck(move: Move, pokemon: Pokemon) {
+  private async replaceMoveCheck(move: Move, pokemon: Pokemon): Promise<void> {
     const learnMovePrompt = i18next.t("battle:learnMovePrompt", {
       pokemonName: getPokemonNameWithAffix(pokemon),
       moveName: move.name,
@@ -108,7 +109,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    * @param move The Move to be learned
    * @param Pokemon The Pokemon learning the move
    */
-  async forgetMoveProcess(move: Move, pokemon: Pokemon) {
+  private async forgetMoveProcess(move: Move, pokemon: Pokemon): Promise<void> {
     globalScene.ui.setMode(this.messageMode);
     await globalScene.ui.showTextPromise(i18next.t("battle:learnMoveForgetQuestion"), undefined, true);
     await globalScene.ui.setModeWithoutClear(
@@ -143,7 +144,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    * @param move The Move to be learned
    * @param Pokemon The Pokemon learning the move
    */
-  async rejectMoveAndEnd(move: Move, pokemon: Pokemon) {
+  private async rejectMoveAndEnd(move: Move, pokemon: Pokemon): Promise<void> {
     if (globalScene.hideMoveSkipConfirm) {
       globalScene.ui.setMode(this.messageMode);
       globalScene.ui
@@ -200,11 +201,8 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    * @param move The Move to be learned
    * @param Pokemon The Pokemon learning the move
    */
-  async learnMove(index: number, move: Move, pokemon: Pokemon, textMessage?: string) {
+  private async learnMove(index: number, move: Move, pokemon: Pokemon, textMessage?: string): Promise<void> {
     if (this.learnMoveType === LearnMoveType.TM) {
-      if (!pokemon.usedTMs) {
-        pokemon.usedTMs = [];
-      }
       if (!pokemon.usedTMs.includes(this.moveId)) {
         pokemon.usedTMs.push(this.moveId);
       }

--- a/src/phases/level-up-phase.ts
+++ b/src/phases/level-up-phase.ts
@@ -81,7 +81,10 @@ export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
   public override end(): void {
     // this if check feels like an unnecessary optimization
     if (this.lastLevel < 100) {
-      const levelMoves = this.getPokemon().getLevelMoves(this.lastLevel + 1, false, true);
+      const levelMoves = this.getPokemon().getLevelMoves({
+        startingLevel: this.lastLevel + 1,
+        includePrevolutionMoves: true,
+      });
       const prevoMoves = levelMoves.filter(
         ([, , source]) => getBaseLearnableMoveSource(source) === LearnableMoveSource.PREVO,
       );

--- a/test/tests/phases/learn-move-phase.test.ts
+++ b/test/tests/phases/learn-move-phase.test.ts
@@ -29,7 +29,7 @@ describe("Learn Move Phase", () => {
     game.move.select(MoveId.SPLASH);
     await game.doKillOpponents();
     await game.phaseInterceptor.to("LearnMovePhase");
-    const levelMove = pokemon.getLevelMoves(5)[0];
+    const levelMove = pokemon.getLevelMoves({ startingLevel: 5 })[0];
     const levelReq = levelMove[0];
     const levelMoveId = levelMove[1];
     expect(pokemon.level).toBeGreaterThanOrEqual(levelReq);
@@ -56,7 +56,7 @@ describe("Learn Move Phase", () => {
     });
     await game.phaseInterceptor.to("LearnMovePhase");
 
-    const levelMove = bulbasaur.getLevelMoves(5)[0];
+    const levelMove = bulbasaur.getLevelMoves({ startingLevel: 5 })[0];
     const levelReq = levelMove[0];
     const levelMoveId = levelMove[1];
     expect(bulbasaur.level).toBeGreaterThanOrEqual(levelReq);
@@ -89,7 +89,7 @@ describe("Learn Move Phase", () => {
     });
     await game.phaseInterceptor.to("LearnMovePhase");
 
-    const levelReq = bulbasaur.getLevelMoves(5)[0][0];
+    const levelReq = bulbasaur.getLevelMoves({ startingLevel: 5 })[0][0];
     expect(bulbasaur.level).toBeGreaterThanOrEqual(levelReq);
     expect(bulbasaur.getMoveset().map(m => m?.moveId)).toEqual(prevMoveset);
   });
@@ -113,7 +113,7 @@ describe("Learn Move Phase", () => {
     });
     await game.phaseInterceptor.to("LearnMovePhase");
 
-    const levelReq = bulbasaur.getLevelMoves(5)[0][0];
+    const levelReq = bulbasaur.getLevelMoves({ startingLevel: 5 })[0][0];
     expect(bulbasaur.level).toBeGreaterThanOrEqual(levelReq);
     expect(bulbasaur.getMoveset().map(m => m?.moveId)).toEqual(prevMoveset);
   });

--- a/test/tests/pokemon/egg-moves.test.ts
+++ b/test/tests/pokemon/egg-moves.test.ts
@@ -1,0 +1,16 @@
+import { speciesDataRegistry } from "#app/global-species-data-registry";
+import { speciesEggMoves } from "#balance/moves/egg-moves";
+import { SpeciesId } from "#enums/species-id";
+import { describe, expect, it } from "vitest";
+
+describe("Egg Moves Definitions", () => {
+  it("has egg moves defined for all possible starters", () => {
+    for (const speciesId of speciesDataRegistry.getAllStarters()) {
+      if (speciesId === SpeciesId.PIKACHU) {
+        continue;
+      }
+      expect(speciesEggMoves).toHaveProperty(String(speciesId));
+      expect(speciesEggMoves[speciesId]).toHaveLength(4);
+    }
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Resolving a `TODO` comment, consolidating some stuff.

## What are the changes from a developer perspective?
Changed `Pokemon#getLevelMoves` to use an object param.
Moved a bunch of move[set]-related methods of the `Pokemon` class together (there's probably more that I missed but the file is an absurd 7000+ LoC).
Added a test to make sure every starter has egg moves defined.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary