### PR TITLE
fix: pre-1.0.3 system data should be loadable again

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -394,36 +394,7 @@ export class GameData {
 
     this.saveSetting(SettingKeys.Player_Gender, systemData.gender === PlayerGender.FEMALE ? 1 : 0);
 
-    if (systemData.starterData) {
-      this.starterData = systemData.starterData;
-    } else {
-      this.initStarterData();
-
-      if (systemData["starterMoveData"]) {
-        const starterMoveData = systemData["starterMoveData"];
-        for (const s of Object.keys(starterMoveData)) {
-          this.starterData[s].moveset = starterMoveData[s];
-        }
-      }
-
-      if (systemData["starterEggMoveData"]) {
-        const starterEggMoveData = systemData["starterEggMoveData"];
-        for (const s of Object.keys(starterEggMoveData)) {
-          this.starterData[s].eggMoves = starterEggMoveData[s];
-        }
-      }
-
-      this.migrateStarterAbilities(systemData, this.starterData);
-
-      const starterIds = Object.keys(this.starterData).map(s => Number.parseInt(s) as SpeciesId);
-      for (const s of starterIds) {
-        this.starterData[s].candyCount += systemData.dexData[s].caughtCount;
-        this.starterData[s].candyCount += systemData.dexData[s].hatchedCount * 2;
-        if (systemData.dexData[s].caughtAttr & DexAttr.SHINY) {
-          this.starterData[s].candyCount += 4;
-        }
-      }
-    }
+    this.starterData = systemData.starterData;
 
     if (systemData.gameStats) {
       this.gameStats = systemData.gameStats;
@@ -454,16 +425,16 @@ export class GameData {
     }
 
     if (systemData.voucherCounts) {
-      getEnumKeys(VoucherType).forEach(key => {
+      for (const key of getEnumKeys(VoucherType)) {
         const index = VoucherType[key];
-        this.voucherCounts[index] = systemData.voucherCounts[index] || 0;
-      });
+        this.voucherCounts[index] = systemData.voucherCounts[index] ?? 0;
+      }
     }
 
-    this.eggs = systemData.eggs ? systemData.eggs.map(e => e.toEgg()) : [];
+    this.eggs = systemData.eggs?.map(e => e.toEgg()) ?? [];
 
-    this.eggPity = systemData.eggPity ? systemData.eggPity.slice(0) : [0, 0, 0, 0];
-    this.unlockPity = systemData.unlockPity ? systemData.unlockPity.slice(0) : [0, 0, 0, 0];
+    this.eggPity = systemData.eggPity?.slice(0) ?? [0, 0, 0, 0];
+    this.unlockPity = systemData.unlockPity?.slice(0) ?? [0, 0, 0, 0];
 
     this.dexData = Object.assign(this.dexData, systemData.dexData);
     this.consolidateDexData(this.dexData);
@@ -471,6 +442,7 @@ export class GameData {
   }
 
   public async initSystem(systemDataStr: string, cachedSystemDataStr?: string): Promise<boolean> {
+    // TODO: is it really a good idea to try to continue on if the system save data is corrupt?
     try {
       let systemData = GameData.parseSystemData(systemDataStr);
 
@@ -2210,30 +2182,6 @@ export class GameData {
       }
       if (!Object.hasOwn(entry, "ribbons")) {
         entry.ribbons = new RibbonData(0);
-      }
-    }
-  }
-
-  migrateStarterAbilities(systemData: SystemSaveData, initialStarterData?: StarterData): void {
-    const starterIds = Object.keys(this.starterData).map(s => Number.parseInt(s) as SpeciesId);
-    const starterData = initialStarterData || systemData.starterData;
-    const dexData = systemData.dexData;
-    for (const s of starterIds) {
-      const dexAttr = dexData[s].caughtAttr;
-      starterData[s].abilityAttr =
-        (dexAttr & DexAttr.DEFAULT_VARIANT ? AbilityAttr.ABILITY_1 : 0)
-        | (dexAttr & DexAttr.VARIANT_2 ? AbilityAttr.ABILITY_2 : 0)
-        | (dexAttr & DexAttr.VARIANT_3 ? AbilityAttr.ABILITY_HIDDEN : 0);
-      if (dexAttr) {
-        if (!(dexAttr & DexAttr.DEFAULT_VARIANT)) {
-          dexData[s].caughtAttr ^= DexAttr.DEFAULT_VARIANT;
-        }
-        if (dexAttr & DexAttr.VARIANT_2) {
-          dexData[s].caughtAttr ^= DexAttr.VARIANT_2;
-        }
-        if (dexAttr & DexAttr.VARIANT_3) {
-          dexData[s].caughtAttr ^= DexAttr.VARIANT_3;
-        }
       }
     }
   }

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -63,6 +63,7 @@ const LATEST_VERSION = version;
 
 // Add migrator imports below
 
+import * as v1_0_3 from "#system/v1_0_3";
 import * as v1_0_4 from "#system/v1_0_4";
 import * as v1_7_0 from "#system/v1_7_0";
 import * as v1_8_3 from "#system/v1_8_3";
@@ -77,6 +78,7 @@ import * as v1_12_0_3 from "#system/v1_12_0_3";
 
 /** All system save migrators */
 const systemMigrators: SystemSaveMigrator[] = [
+  ...v1_0_3.systemMigrators,
   ...v1_0_4.systemMigrators,
   ...v1_7_0.systemMigrators,
   ...v1_8_3.systemMigrators,

--- a/src/system/version-migration/versions/v1_0_3.ts
+++ b/src/system/version-migration/versions/v1_0_3.ts
@@ -1,0 +1,81 @@
+import { defaultStarterSpecies } from "#app/constants";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
+import { AbilityAttr } from "#enums/ability-attr";
+import { DexAttr } from "#enums/dex-attr";
+import type { SystemSaveData } from "#types/save-data";
+import type { SystemSaveMigrator } from "#types/save-migrators";
+
+const createStarterData: SystemSaveMigrator = {
+  name: "createStarterData",
+  version: "1.0.3",
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: it's simpler this way
+  migrate: (data: SystemSaveData): void => {
+    if (data.starterData != null) {
+      return;
+    }
+
+    const allStarterIds = speciesDataRegistry.getAllStarters();
+
+    data.starterData = {};
+    for (const speciesId of allStarterIds) {
+      data.starterData[speciesId] = {
+        moveset: null,
+        eggMoves: 0,
+        candyCount: 0,
+        friendship: 0,
+        abilityAttr: defaultStarterSpecies.includes(speciesId) ? AbilityAttr.ABILITY_1 : 0,
+        passiveAttr: 0,
+        valueReduction: 0,
+        classicWinCount: 0,
+      };
+    }
+
+    if (data["starterMoveData"]) {
+      const starterMoveData = data["starterMoveData"];
+      for (const s of Object.keys(starterMoveData)) {
+        data.starterData[s].moveset = starterMoveData[s];
+      }
+      data["starterMoveData"] = undefined;
+    }
+
+    if (data["starterEggMoveData"]) {
+      const starterEggMoveData = data["starterEggMoveData"];
+      for (const s of Object.keys(starterEggMoveData)) {
+        data.starterData[s].eggMoves = starterEggMoveData[s];
+      }
+      data["starterEggMoveData"] = undefined;
+    }
+
+    for (const starter of allStarterIds) {
+      if (data.dexData[starter] == null) {
+        continue;
+      }
+      const caughtAttr = data.dexData[starter].caughtAttr;
+
+      data.starterData[starter].abilityAttr =
+        (caughtAttr & DexAttr.DEFAULT_VARIANT ? AbilityAttr.ABILITY_1 : 0)
+        | (caughtAttr & DexAttr.VARIANT_2 ? AbilityAttr.ABILITY_2 : 0)
+        | (caughtAttr & DexAttr.VARIANT_3 ? AbilityAttr.ABILITY_HIDDEN : 0);
+
+      if (caughtAttr) {
+        if (!(caughtAttr & DexAttr.DEFAULT_VARIANT)) {
+          data.dexData[starter].caughtAttr ^= DexAttr.DEFAULT_VARIANT;
+        }
+        if (caughtAttr & DexAttr.VARIANT_2) {
+          data.dexData[starter].caughtAttr ^= DexAttr.VARIANT_2;
+        }
+        if (caughtAttr & DexAttr.VARIANT_3) {
+          data.dexData[starter].caughtAttr ^= DexAttr.VARIANT_3;
+        }
+      }
+
+      data.starterData[starter].candyCount += data.dexData[starter].caughtCount;
+      data.starterData[starter].candyCount += data.dexData[starter].hatchedCount * 2;
+      if (data.dexData[starter].caughtAttr & DexAttr.SHINY) {
+        data.starterData[starter].candyCount += 4;
+      }
+    }
+  },
+};
+
+export const systemMigrators: readonly SystemSaveMigrator[] = [createStarterData] as const;


### PR DESCRIPTION
## What are the changes the user will see?
Save data from pre-1.0.3 will be able to be loaded again.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
- Fixes #7559

## What are the changes from a developer perspective?
Moved the pre-1.0.3 (actually I think it might even be for pre-1.0.2 saves) migration code to run before the other data migrators instead of after by putting it into the actual migrator code.

## How to test the changes?
Import a very old save (such as the one from #7559). You'll need to pull in the commits from #7560 to import it though (you can do this by applying the patch files below, or checking out the PR and cherry-picking the commits from it to this PR's branch locally).

[0001-dev-allow-importing-of-decrypted-raw-JSON-saves.txt](https://github.com/user-attachments/files/30185686/0001-dev-allow-importing-of-decrypted-raw-JSON-saves.txt)
[0002-Allow-.json-and-.txt-file-extensions-for-save-import.txt](https://github.com/user-attachments/files/30185688/0002-Allow-.json-and-.txt-file-extensions-for-save-import.txt)

Rename the files from `.txt` to `.patch`, or copy the text from the collapsible block below into patch files (GitHub gets weird with uploaded files sometimes...).

<details><summary>Patch files for 7560 as text</summary>

<details><summary>0001-dev-allow-importing-of-decrypted-raw-JSON-saves.patch</summary>

0001-dev-allow-importing-of-decrypted-raw-JSON-saves.patch

```patch
From 5c0f7e8b5b27ac9b95dae4fd1ae918dd49e8eb80 Mon Sep 17 00:00:00 2001
From: NightKev <34855794+DayKev@users.noreply.github.com>
Date: Sat, 18 Jul 2026 23:28:53 -0700
Subject: [PATCH 1/2] dev: allow importing of decrypted (raw JSON) saves

---
 scripts/decrypt-save.ts        | 25 ++--------------
 src/constants/app-constants.ts | 19 ++++++++++++
 src/system/game-data.ts        | 53 +++++++++++++---------------------
 src/utils/data.ts              | 10 +++++++
 test/framework/game-manager.ts |  2 +-
 5 files changed, 52 insertions(+), 57 deletions(-)

diff --git a/scripts/decrypt-save.ts b/scripts/decrypt-save.ts
index e3f1f32f2cd..0f3918e034c 100644
--- a/scripts/decrypt-save.ts
+++ b/scripts/decrypt-save.ts
@@ -10,6 +10,7 @@
  */
 
 import { saveKey as SAVE_KEY } from "#app/constants";
+import { systemSaveShortKeyMap } from "#constants/app-constants";
 import { defaultCommanderHelpArgs } from "#script-utils/arguments";
 import fs from "node:fs";
 import { Command } from "@commander-js/extra-typings";
@@ -19,35 +20,13 @@ const { AES, enc } = cryptoJs;
 
 const version = "1.0.0";
 
-/**
- * A map of condensed keynames to their associated full names.
- */
-// TODO: Move `src/system/game-data#systemShortKeys` to a new file and import it here
-const systemShortKeys = {
-  seenAttr: "$sa",
-  caughtAttr: "$ca",
-  natureAttr: "$na",
-  seenCount: "$s",
-  caughtCount: "$c",
-  hatchedCount: "$hc",
-  ivs: "$i",
-  moveset: "$m",
-  eggMoves: "$em",
-  candyCount: "$x",
-  friendship: "$f",
-  abilityAttr: "$a",
-  passiveAttr: "$pa",
-  valueReduction: "$vr",
-  classicWinCount: "$wc",
-} as const;
-
 /**
  * Replace the shortened key names with their full names.
  * @param dataStr - The string to convert
  * @returns The string with shortened keynames replaced with full names
  */
 function convertSystemDataStr(dataStr: string): string {
-  for (const [fullKey, abbreviated] of Object.entries(systemShortKeys)) {
+  for (const [fullKey, abbreviated] of Object.entries(systemSaveShortKeyMap)) {
     dataStr = dataStr.replace(new RegExp(`${abbreviated.replace("$", "\\$")}`, "g"), fullKey);
   }
   return dataStr;
diff --git a/src/constants/app-constants.ts b/src/constants/app-constants.ts
index c249e1496d0..7a0ea81aa08 100644
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -19,3 +19,22 @@ export const isApp = import.meta.env.MODE === "app";
 export const IS_TEST = import.meta.env.MODE === "test";
 
 export const bypassLogin = import.meta.env.VITE_BYPASS_LOGIN === "1";
+
+/** A map of condensed keynames to their associated full names. */
+export const systemSaveShortKeyMap = {
+  seenAttr: "$sa",
+  caughtAttr: "$ca",
+  natureAttr: "$na",
+  seenCount: "$s",
+  caughtCount: "$c",
+  hatchedCount: "$hc",
+  ivs: "$i",
+  moveset: "$m",
+  eggMoves: "$em",
+  candyCount: "$x",
+  friendship: "$f",
+  abilityAttr: "$a",
+  passiveAttr: "$pa",
+  valueReduction: "$vr",
+  classicWinCount: "$wc",
+} as const;
diff --git a/src/system/game-data.ts b/src/system/game-data.ts
index 1daa9b609fb..f07f7af4d78 100644
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -9,7 +9,7 @@ import { activeOverrides } from "#app/overrides";
 import { isIos } from "#app/touch-controls";
 import { Tutorial } from "#app/tutorial";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
-import { bypassLogin, isBeta, isDev } from "#constants/app-constants";
+import { bypassLogin, isBeta, isDev, systemSaveShortKeyMap } from "#constants/app-constants";
 import { MAX_STARTER_CANDY_COUNT } from "#constants/game-constants";
 import { EntryHazardTag } from "#data/arena-tag";
 import { getSerializedDailyRunConfig, parseDailySeed } from "#data/daily-seed/daily-seed-utils";
@@ -74,7 +74,7 @@ import type {
 import { RUN_HISTORY_LIMIT } from "#ui/run-history-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
 import { fixedInt, NumberHolder, randInt, randSeedItem } from "#utils/common";
-import { decrypt, encrypt } from "#utils/data";
+import { decrypt, encrypt, isValidJSON } from "#utils/data";
 import { getEnumKeys } from "#utils/enums";
 import { toCamelCase } from "#utils/strings";
 import { AES, enc } from "crypto-js";
@@ -102,24 +102,6 @@ function getDataTypeKey(dataType: GameDataType, slotId = 0): string {
   }
 }
 
-const systemShortKeys = {
-  seenAttr: "$sa",
-  caughtAttr: "$ca",
-  natureAttr: "$na",
-  seenCount: "$s",
-  caughtCount: "$c",
-  hatchedCount: "$hc",
-  ivs: "$i",
-  moveset: "$m",
-  eggMoves: "$em",
-  candyCount: "$x",
-  friendship: "$f",
-  abilityAttr: "$a",
-  passiveAttr: "$pa",
-  valueReduction: "$vr",
-  classicWinCount: "$wc",
-};
-
 const ErrorMessages = {
   OUT_OF_DATE: i18next.t("gameData:reloadSaveData"),
   OUT_OF_DATE_LOCAL: i18next.t("gameData:reloadSaveDataLocal"),
@@ -592,15 +574,15 @@ export class GameData {
     return ret;
   }
 
-  convertSystemDataStr(dataStr: string, shorten = false): string {
+  private convertSystemDataStr(dataStr: string, shorten = false): string {
     if (!shorten) {
       // Account for past key oversight
       dataStr = dataStr.replace(/\$pAttr/g, "$pa");
     }
     dataStr = dataStr.replace(/"trainerId":\d+/g, `"trainerId":${this.trainerId}`);
     dataStr = dataStr.replace(/"secretId":\d+/g, `"secretId":${this.secretId}`);
-    const fromKeys = shorten ? Object.keys(systemShortKeys) : Object.values(systemShortKeys);
-    const toKeys = shorten ? Object.values(systemShortKeys) : Object.keys(systemShortKeys);
+    const fromKeys = shorten ? Object.keys(systemSaveShortKeyMap) : Object.values(systemSaveShortKeyMap);
+    const toKeys = shorten ? Object.values(systemSaveShortKeyMap) : Object.keys(systemSaveShortKeyMap);
     for (const k in fromKeys) {
       dataStr = dataStr.replace(new RegExp(`${fromKeys[k].replace("$", "\\$")}`, "g"), toKeys[k]);
     }
@@ -1463,12 +1445,9 @@ export class GameData {
   public importData(dataType: GameDataType, slotId = 0): void {
     const dataKey = `${getDataTypeKey(dataType, slotId)}_${loggedInUser?.username}`;
 
-    let saveFile: any = document.getElementById("saveFile");
-    if (saveFile) {
-      saveFile.remove();
-    }
+    document.getElementById("saveFile")?.remove();
 
-    saveFile = document.createElement("input");
+    const saveFile = document.createElement("input");
     saveFile.id = "saveFile";
     saveFile.type = "file";
     saveFile.accept = ".prsv";
@@ -1525,7 +1504,7 @@ export class GameData {
       saveFile.style.display = "none";
     }
 
-    saveFile.addEventListener("change", e => {
+    saveFile.addEventListener("change", ev => {
       const overlay = document.getElementById("iosUploadOverlay");
       const button = document.getElementById("iosUploadButton");
       overlay?.remove();
@@ -1535,9 +1514,17 @@ export class GameData {
 
       reader.onload = (_ => {
         return e => {
-          const dataName = i18next.t(`gameData:${toCamelCase(GameDataType[dataType])}`);
-          let dataStr = AES.decrypt(e.target?.result?.toString()!, saveKey).toString(enc.Utf8); // TODO: is this bang correct?
           let valid = false;
+          const dataName = i18next.t(`gameData:${toCamelCase(GameDataType[dataType])}`);
+          const saveData = e.target?.result?.toString() ?? "";
+
+          let dataStr: string;
+          if (isValidJSON(saveData)) {
+            dataStr = saveData;
+          } else {
+            dataStr = AES.decrypt(saveData, saveKey).toString(enc.Utf8);
+          }
+
           try {
             switch (dataType) {
               case GameDataType.SYSTEM: {
@@ -1628,9 +1615,9 @@ export class GameData {
             );
           });
         };
-      })((e.target as any).files[0]);
+      })((ev.target as any).files[0]);
 
-      reader.readAsText((e.target as any).files[0]);
+      reader.readAsText((ev.target as any).files[0]);
     });
 
     if (!isIos()) {
diff --git a/src/utils/data.ts b/src/utils/data.ts
index 046f7f855d9..9b1d7ce2f77 100644
--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -107,3 +107,13 @@ export function saveStarterPreferences(prefs: StarterPreferences): void {
     StarterPrefers_private_latest = pStr;
   }
 }
+
+/** @returns Whether the input is valid JSON */
+export function isValidJSON(str: string): boolean {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
diff --git a/test/framework/game-manager.ts b/test/framework/game-manager.ts
index 42cd10c10b7..5076d603749 100644
--- a/test/framework/game-manager.ts
+++ b/test/framework/game-manager.ts
@@ -439,7 +439,7 @@ export class GameManager {
     const saveKey = "x0i2O7WRiANTqPmZ";
     const dataRaw = fs.readFileSync(path, { encoding: "utf8", flag: "r" });
     let dataStr = AES.decrypt(dataRaw, saveKey).toString(enc.Utf8);
-    dataStr = this.scene.gameData.convertSystemDataStr(dataStr);
+    dataStr = this.scene.gameData["convertSystemDataStr"](dataStr);
     const systemData = GameData.parseSystemData(dataStr);
     const valid = !!systemData.dexData && !!systemData.timestamp;
     if (valid) {
-- 
2.55.0.windows.3


```

</details>
<details><summary>0002-Allow-.json-and-.txt-file-extensions-for-save-import.patch</summary>

0002-Allow-.json-and-.txt-file-extensions-for-save-import.patch

```patch
From 35dd8c4dc464ef1fdfae39c7315a0cfa0683d47e Mon Sep 17 00:00:00 2001
From: NightKev <34855794+DayKev@users.noreply.github.com>
Date: Mon, 20 Jul 2026 02:17:04 -0700
Subject: [PATCH 2/2] Allow `.json` and `.txt` file extensions for save
 importing

---
 src/system/game-data.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/src/system/game-data.ts b/src/system/game-data.ts
index f07f7af4d78..1d996f0fa65 100644
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1450,7 +1450,7 @@ export class GameData {
     const saveFile = document.createElement("input");
     saveFile.id = "saveFile";
     saveFile.type = "file";
-    saveFile.accept = ".prsv";
+    saveFile.accept = ".prsv, .json, .txt";
 
     // iOS requires user interaction with a visible element to trigger file input
     if (isIos()) {
-- 
2.55.0.windows.3


```

</details>
</details> 

## Checklist
- The PR content is correctly formatted:
  - ~[ ] **I'm using `beta` as my base branch**~
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually