### PR TITLE
fix(challenge): Challenge ribbons will be awarded to all eligible Pokémon

### DIFF
--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -8,6 +8,7 @@ import { modifierTypes } from "#data/data-lists";
 import { getCharVariantFromDialogue } from "#data/dialogue";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { BattleType } from "#enums/battle-type";
+import { ChallengeType } from "#enums/challenge-type";
 import { Challenges } from "#enums/challenges";
 import { PlayerGender } from "#enums/player-gender";
 import { TrainerType } from "#enums/trainer-type";
@@ -26,8 +27,9 @@ import { awardRibbonsToSpeciesLine } from "#system/ribbons/ribbon-methods";
 import { TrainerData } from "#system/trainer-data";
 import { trainerConfigs } from "#trainers/trainer-config";
 import type { SessionSaveData } from "#types/save-data";
-import { checkSpeciesValidForChallenge, isNuzlockeChallenge } from "#utils/challenge-utils";
+import { applyChallenges, isNuzlockeChallenge } from "#utils/challenge-utils";
 import { fixedInt, isLocalServerConnected } from "#utils/common";
+import { ValueHolder } from "#utils/value-holder";
 import i18next from "i18next";
 
 export class GameOverPhase extends BattlePhase {
@@ -150,16 +152,12 @@ export class GameOverPhase extends BattlePhase {
       }
     }
     // Award ribbons to all Pokémon in the player's party that are considered valid
-    // for the current game mode and challenges.
+    // for the current game mode and challenges (as in, they can be used in battle).
     for (const pokemon of globalScene.getPlayerParty()) {
       const species = pokemon.species;
-      if (
-        checkSpeciesValidForChallenge(
-          species,
-          globalScene.gameData.getSpeciesDexAttrProps(species, pokemon.getDexAttr()),
-          false,
-        )
-      ) {
+      const challengeAllowed = new ValueHolder(true);
+      applyChallenges(ChallengeType.POKEMON_IN_BATTLE, pokemon, challengeAllowed);
+      if (challengeAllowed.value) {
         awardRibbonsToSpeciesLine(species.speciesId, ribbonFlags as RibbonFlag);
       }
     }


### PR DESCRIPTION
## What are the changes the user will see?
After completing a challenge run, ribbons will be awarded to all eligible mons in the party.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Until now, the code awarding ribbons was checking that each mon was eligible as a starter. While in most cases this coincided with eligibility for the challenge, in the Full Reset challenge all mons (almost) can be caught and used, but only the original 27 can be chosen as starters. This caused ribbons to only be awarded to those 27.

## What are the changes from a developer perspective?
We still need to check for eligibility (e.g. not give the mono_fire ribbon to a Squirtle). This is now done through a`applyChallenges(ChallengeType.POKEMON_IN_BATTLE)` call, which checks whether the mon can be used in battle in the current run.

## Screenshots/Videos

## How to test the changes?
Load a save data where some mons do not have fresh start ribbons (e.g. everything.prsv) and start a Full Reset challenge run. Use overrides to quickly get to the end, while catching a wild mon in between. Check that the caught wild mon now has a fresh start ribbon.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
