### PR TITLE
fix!: remove invalid starter and dex data

### DIFF
--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -73,6 +73,7 @@ import * as v1_11_19 from "#system/v1_11_19";
 import * as v1_12_0_0 from "#system/v1_12_0_0";
 import * as v1_12_0_1 from "#system/v1_12_0_1";
 import * as v1_12_0_3 from "#system/v1_12_0_3";
+import * as v1_12_0_10 from "#system/v1_12_0_10";
 
 // To add a new set of migrators, add them to the appropriate array of migrators
 
@@ -85,6 +86,7 @@ const systemMigrators: SystemSaveMigrator[] = [
   ...v1_12_0_0.systemMigrators,
   ...v1_12_0_1.systemMigrators,
   ...v1_12_0_3.systemMigrators,
+  ...v1_12_0_10.systemMigrators,
 ];
 
 /** All session save migrators */

--- a/src/system/version-migration/versions/v1_12_0_10.ts
+++ b/src/system/version-migration/versions/v1_12_0_10.ts
@@ -1,0 +1,49 @@
+import { speciesDataRegistry } from "#app/global-species-data-registry";
+import { SpeciesId } from "#enums/species-id";
+import type { SystemSaveData } from "#types/save-data";
+import type { SystemSaveMigrator } from "#types/save-migrators";
+
+function removeInvalidStarterData(data: SystemSaveData): void {
+  if (!data.starterData) {
+    console.error("Starter data is missing! Skipping starter data fixing.");
+    return;
+  }
+
+  for (const s of Object.keys(data.starterData)) {
+    if (!SpeciesId[s]) {
+      console.warn(`Invalid species ID "${s}" found in starter data, removing entry...`);
+      delete data.starterData[s];
+      return;
+    }
+
+    if (!speciesDataRegistry.isStarter(Number(s))) {
+      console.warn(`Species "${SpeciesId[s]}" is not a valid starter, removing entry...`);
+      delete data.starterData[s];
+    }
+  }
+}
+
+function removeInvalidDexData(data: SystemSaveData): void {
+  if (!data.dexData) {
+    console.error("Dex data is missing! Skipping dex data fixing.");
+    return;
+  }
+
+  for (const s of Object.keys(data.dexData)) {
+    if (!SpeciesId[s]) {
+      console.warn(`Invalid species ID "${s}" found in dex data, removing entry...`);
+      delete data.dexData[s];
+    }
+  }
+}
+
+const removeInvalidStarterAndDexData: SystemSaveMigrator = {
+  name: "removeInvalidStarterAndDexData",
+  version: "1.12.0.10",
+  migrate: (data: SystemSaveData): void => {
+    removeInvalidStarterData(data);
+    removeInvalidDexData(data);
+  },
+};
+
+export const systemMigrators: readonly SystemSaveMigrator[] = [removeInvalidStarterAndDexData] as const;

--- a/src/system/version-migration/versions/v1_7_0.ts
+++ b/src/system/version-migration/versions/v1_7_0.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { DexAttr } from "#enums/dex-attr";
-import type { SpeciesId } from "#enums/species-id";
+import { SpeciesId } from "#enums/species-id";
 import type { SystemSaveData } from "#types/save-data";
 import type { SessionSaveMigrator, SystemSaveMigrator } from "#types/save-migrators";
 import { validateIsArrayOfObjects } from "#utils/migrator-utils";
@@ -20,8 +20,9 @@ const migrateUnselectableForms: SystemSaveMigrator = {
       Object.keys(data.starterData).forEach(sd => {
         const caughtAttr = data.dexData[sd]?.caughtAttr;
         const speciesNumber = Number(sd);
-        if (!speciesNumber) {
-          // An unknown bug at some point in time caused some accounts to have starter data for pokedex number 0 which crashes
+        if (!speciesNumber || !SpeciesId[speciesNumber]) {
+          // An unknown bug at some point in time caused some accounts to have starter data for pokedex number 0 which crashes.
+          // An unknown bug caused some accounts to have data for species that don't exist.
           return;
         }
         const species = speciesDataRegistry.getSpecies(speciesNumber);


### PR DESCRIPTION
## What are the changes the user will see?
Accounts with invalid entries in starter or dex data will have the invalid entries removed from save data, allowing them to load the game.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Somehow some account(s) had entries for species that don't exist in their starter and/or dex data, causing the game to be unable to load the data and thus rendering the account unplayable.

## What are the changes from a developer perspective?
- Added a check in the `1.7.0` system migrator to prevent it throwing an error if there is an invalid species ID in the data.
- Added a `1.12.0.10` migrator that removes invalid entries from starter and dex data.

## How to test the changes?
Import a save with invalid starter or dex entries, such as this one (rename from `.txt` to `.prsv`):
[systemData-invalid-species.txt](https://github.com/user-attachments/files/30260211/systemData-invalid-species.txt)

## Checklist
- The PR content is correctly formatted:
  - ~[ ] **I'm using `beta` as my base branch**~
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually