### PR TITLE
fix: the game will refuse to load if the save version is newer

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -36,6 +36,7 @@ import type { EnemyPokemon, PlayerPokemon, Pokemon } from "#field/pokemon";
 // biome-ignore lint/performance/noNamespaceImport: Something weird is going on here and I don't want to touch it
 import * as Modifier from "#modifiers/modifier";
 import { MysteryEncounterSaveData } from "#mystery-encounters/mystery-encounter-save-data";
+import { version } from "#package.json";
 import type { Variant } from "#sprites/variant";
 import { achvs } from "#system/achv";
 import { ArenaData, type SerializedArenaData } from "#system/arena-data";
@@ -76,6 +77,7 @@ import { applyChallenges } from "#utils/challenge-utils";
 import { fixedInt, NumberHolder, randInt, randSeedItem } from "#utils/common";
 import { decrypt, encrypt } from "#utils/data";
 import { getEnumKeys } from "#utils/enums";
+import { compareVersions } from "#utils/migrator-utils";
 import { toCamelCase } from "#utils/strings";
 import { AES, enc } from "crypto-js";
 import i18next from "i18next";
@@ -118,7 +120,7 @@ const systemShortKeys = {
   passiveAttr: "$pa",
   valueReduction: "$vr",
   classicWinCount: "$wc",
-};
+} as const;
 
 const ErrorMessages = {
   OUT_OF_DATE: i18next.t("gameData:reloadSaveData"),
@@ -126,7 +128,8 @@ const ErrorMessages = {
   DATA_NOT_FOUND: i18next.t("gameData:saveDataNotFound"),
   TOO_MANY_CONNECTIONS: i18next.t("gameData:tooManyConnections"),
   FAILED_VALIDATION: i18next.t("gameData:failedSaveValidation"),
-};
+  GAME_OUT_OF_DATE: i18next.t("gameData:gameOutOfDate"),
+} as const;
 
 export class GameData {
   public trainerId: number;
@@ -367,7 +370,7 @@ export class GameData {
   }
 
   /**
-   *
+   * Used by the admin panel when searching for user accounts.
    * @param dataStr - The raw JSON string of the `SystemSaveData`
    * @returns - A new `GameData` instance initialized with the parsed `SystemSaveData`
    */
@@ -441,7 +444,7 @@ export class GameData {
     this.defaultDexData = null;
   }
 
-  public async initSystem(systemDataStr: string, cachedSystemDataStr?: string): Promise<boolean> {
+  private async initSystem(systemDataStr: string, cachedSystemDataStr?: string): Promise<boolean> {
     // TODO: is it really a good idea to try to continue on if the system save data is corrupt?
     try {
       let systemData = GameData.parseSystemData(systemDataStr);
@@ -478,6 +481,16 @@ export class GameData {
         localStorage.setItem(lsItemKey, "");
       }
 
+      if (!isDev && !isBeta && compareVersions(systemData.gameVersion, version) === 1) {
+        await globalScene.ui.setMode(UiMode.ALERT_MODAL, ErrorMessages.GAME_OUT_OF_DATE);
+
+        globalScene.time.delayedCall(fixedInt(1000), () => {
+          if (globalScene.ui.getMode() !== UiMode.ALERT_MODAL) {
+            globalScene.ui.setMode(UiMode.ALERT_MODAL, ErrorMessages.GAME_OUT_OF_DATE);
+          }
+        });
+        return false;
+      }
       this.initParsedSystem(systemData);
       return true;
     } catch (err) {

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -9,7 +9,7 @@ import type {
   SettingsSaveMigrator,
   SystemSaveMigrator,
 } from "#types/save-migrators";
-import { validateIsArrayOfObjects } from "#utils/migrator-utils";
+import { compareVersions, validateIsArrayOfObjects } from "#utils/migrator-utils";
 
 /*
 // template for save migrator creation
@@ -214,58 +214,6 @@ function applyMigrators(migrators: readonly SaveMigrator[], data: SaveData, save
       }
     }
   }
-}
-
-/**
- * Converts a version string into an array of numbers for use in the comparison function.
- * @param versionString - The version to convert
- * @returns An array of numbers corresponding to the input version
- * @throws An error if the version string is not valid (of the form "#.#.#[.#]")
- * @example
- * ```ts
- * extractVersion("1.2.3"); // output: [1, 2, 3, 0]
- * extractVersion("1.2.3.4"); // output: [1, 2, 3, 4]
- * extractVersion("1..2.3"); // throws error
- * extractVersion("1.2.3.4.5"); // throws error
- * ```
- */
-function extractVersion(versionString: string): number[] {
-  // https://regex101.com/r/7r1299/1
-  const regex = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
-  if (!regex.test(versionString)) {
-    throw new Error(`Invalid version string (${versionString}) in version migrator!`);
-  }
-
-  const versionArray = versionString.split(".").map(v => Number.parseInt(v));
-  if (versionArray.length === 3) {
-    versionArray.push(0);
-  }
-  return versionArray;
-}
-
-/**
- * Compares two versions and returns whether one is newer than the other.
- * @param versionA - The first version to compare
- * @param versionB - The second version to compare
- * @returns The result of the comparison:
- * - `1`: `versionA` is newer
- * - `-1`: `versionB` is newer
- * - `0`: The versions are equal
- */
-function compareVersions(versionA: string, versionB: string): -1 | 0 | 1 {
-  const a = extractVersion(versionA);
-  const b = extractVersion(versionB);
-
-  for (let i = 0; i < 4; i++) {
-    if (a[i] > b[i]) {
-      return 1;
-    }
-    if (a[i] < b[i]) {
-      return -1;
-    }
-  }
-
-  return 0;
 }
 
 // #endregion Utility Functions

--- a/src/utils/migrator-utils.ts
+++ b/src/utils/migrator-utils.ts
@@ -43,3 +43,55 @@ export function isPropertyAnObject<const T extends string>(
 ): data is Record<string, unknown> & Record<T, Record<string, unknown>> {
   return typeof data[property] === "object" && data[property] !== null;
 }
+
+/**
+ * Converts a version string into an array of numbers for use in the comparison function.
+ * @param versionString - The version to convert
+ * @returns An array of numbers corresponding to the input version
+ * @throws An error if the version string is not valid (of the form "#.#.#[.#]")
+ * @example
+ * ```ts
+ * extractVersion("1.2.3"); // output: [1, 2, 3, 0]
+ * extractVersion("1.2.3.4"); // output: [1, 2, 3, 4]
+ * extractVersion("1..2.3"); // throws error
+ * extractVersion("1.2.3.4.5"); // throws error
+ * ```
+ */
+function extractVersion(versionString: string): number[] {
+  // https://regex101.com/r/7r1299/1
+  const regex = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
+  if (!regex.test(versionString)) {
+    throw new Error(`Invalid version string (${versionString}) in version migrator!`);
+  }
+
+  const versionArray = versionString.split(".").map(v => Number.parseInt(v));
+  if (versionArray.length === 3) {
+    versionArray.push(0);
+  }
+  return versionArray;
+}
+
+/**
+ * Compares two versions and returns whether one is newer than the other.
+ * @param versionA - The first version to compare
+ * @param versionB - The second version to compare
+ * @returns The result of the comparison:
+ * - `1`: `versionA` is newer
+ * - `-1`: `versionB` is newer
+ * - `0`: The versions are equal
+ */
+export function compareVersions(versionA: string, versionB: string): -1 | 0 | 1 {
+  const a = extractVersion(versionA);
+  const b = extractVersion(versionB);
+
+  for (let i = 0; i < 4; i++) {
+    if (a[i] > b[i]) {
+      return 1;
+    }
+    if (a[i] < b[i]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}

--- a/test/framework/game-manager.ts
+++ b/test/framework/game-manager.ts
@@ -444,7 +444,7 @@ export class GameManager {
     const valid = !!systemData.dexData && !!systemData.timestamp;
     if (valid) {
       await updateUserInfo();
-      await this.scene.gameData.initSystem(dataStr);
+      await this.scene.gameData["initSystem"](dataStr);
     }
     return updateUserInfo();
   }


### PR DESCRIPTION
## What are the changes the user will see?
The game will refuse to load if the version of the user's save data is greater than the current client's version.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Prevents the user somehow getting out of sync save data, which wouldn't be able to be loaded.

## What are the changes from a developer perspective?
Added a check in `GameData#initSystem` that causes loading to fail if the save data's version is greater than the client version (which would indicate somehow the user's client version got downgraded at some point).

## Screenshots/Videos
See associated locales PR.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually

Are there any localization additions or changes? If so:
- [x] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-locales/pull/348
- [x] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)