### PR TITLE
github: fix permissions for "Label PRs" workflow

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
+  issues: write
 
 jobs:
   label-prs:


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing workflow.

## What are the changes from a developer perspective?
Changed the permissions for the workflow from `pull-requests: write` to `issues: write`.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR