### PR TITLE
dev: clean up build logging when building locally

### DIFF
--- a/plugins/vite/vite-minify-json-plugin.ts
+++ b/plugins/vite/vite-minify-json-plugin.ts
@@ -9,11 +9,12 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import readline from "node:readline";
 import chalk from "chalk";
 import type { Logger, Plugin as VitePlugin } from "vite";
 
 const NAME = "minify-public-json-files";
-const VERSION = "3.0.0";
+const VERSION = "3.1.0";
 
 /** Patterns that should be excluded, meant to be excluded at any level */
 const EXCLUDE_PATTERNS = ["REUSE.toml", ".git", "LICENSE", "README.md", "package.json", "pnpm-lock.yaml"];
@@ -46,6 +47,13 @@ export function minifyPublicJsonFiles(): VitePlugin {
       logger.info(cyan(`\t→ Plugin: ${NAME} v${VERSION}`));
     },
     async generateBundle(options): Promise<void> {
+      const clearLine = (): void => {
+        if (!process.env.CI) {
+          readline.moveCursor(process.stdout, 0, -1);
+          readline.clearLine(process.stdout, 0);
+        }
+      };
+
       // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: good enough
       const minifyJsonFiles = (dir: string, outDir: string): void => {
         const files = fs.readdirSync(dir);
@@ -56,11 +64,13 @@ export function minifyPublicJsonFiles(): VitePlugin {
           const stat = fs.statSync(fullPath);
 
           if (skipExcludes(file)) {
+            clearLine();
             logger.info(yellow(`Skipping "${fullPath}".`));
             continue;
           }
 
           if (stat.isDirectory()) {
+            clearLine();
             logger.info(green(`Processing directory "${fullPath}".`));
             // Recurse into subdirectories
             const nestedOutputDir = path.join(outDir, file);
@@ -68,6 +78,7 @@ export function minifyPublicJsonFiles(): VitePlugin {
             minifyJsonFiles(fullPath, nestedOutputDir);
             continue;
           }
+
           if (file.endsWith(".json")) {
             try {
               // Minify JSON file
@@ -83,6 +94,7 @@ export function minifyPublicJsonFiles(): VitePlugin {
             }
             continue;
           }
+
           // Copy other files as-is
           fs.copyFileSync(fullPath, outputFilePath);
         }
@@ -94,6 +106,9 @@ export function minifyPublicJsonFiles(): VitePlugin {
       const localesDir = path.resolve("./locales");
       const outputDir = path.resolve(options.dir || "dist");
 
+      if (!process.env.CI) {
+        logger.info("");
+      }
       minifyJsonFiles(assetsDir, outputDir);
       minifyJsonFiles(localesDir, path.join(outputDir, "locales"));
 

--- a/plugins/vite/vite-minify-json-plugin.ts
+++ b/plugins/vite/vite-minify-json-plugin.ts
@@ -54,7 +54,20 @@ export function minifyPublicJsonFiles(): VitePlugin {
         }
       };
 
-      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: good enough
+      const minifyFile = (fullPath: string, outputFilePath: string): void => {
+        try {
+          const content = fs.readFileSync(fullPath, "utf-8");
+          const minifiedContent = JSON.stringify(JSON.parse(content));
+          fs.writeFileSync(outputFilePath, minifiedContent, "utf-8");
+          count++;
+        } catch (err) {
+          fs.copyFileSync(fullPath, outputFilePath);
+          const error = new Error(`Failed to minify JSON file: ${fullPath}\n\t→ ${err.message}`);
+          error.stack = err.stack;
+          errors.push(error);
+        }
+      };
+
       const minifyJsonFiles = (dir: string, outDir: string): void => {
         const files = fs.readdirSync(dir);
 
@@ -80,18 +93,7 @@ export function minifyPublicJsonFiles(): VitePlugin {
           }
 
           if (file.endsWith(".json")) {
-            try {
-              // Minify JSON file
-              const content = fs.readFileSync(fullPath, "utf-8");
-              const minifiedContent = JSON.stringify(JSON.parse(content));
-              fs.writeFileSync(outputFilePath, minifiedContent, "utf-8");
-              count++;
-            } catch (err) {
-              fs.copyFileSync(fullPath, outputFilePath);
-              const error = new Error(`Failed to minify JSON file: ${fullPath}\n\t→ ${err.message}`);
-              error.stack = err.stack;
-              errors.push(error);
-            }
+            minifyFile(fullPath, outputFilePath);
             continue;
           }
 

--- a/plugins/vite/vite-minify-json-plugin.ts
+++ b/plugins/vite/vite-minify-json-plugin.ts
@@ -7,9 +7,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import fs from "node:fs";
-import path from "node:path";
-import readline from "node:readline";
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { clearLine, moveCursor } from "node:readline";
 import chalk from "chalk";
 import type { Logger, Plugin as VitePlugin } from "vite";
 
@@ -47,21 +47,21 @@ export function minifyPublicJsonFiles(): VitePlugin {
       logger.info(cyan(`\t→ Plugin: ${NAME} v${VERSION}`));
     },
     async generateBundle(options): Promise<void> {
-      const clearLine = (): void => {
+      const clearTerminalLine = (): void => {
         if (!process.env.CI) {
-          readline.moveCursor(process.stdout, 0, -1);
-          readline.clearLine(process.stdout, 0);
+          moveCursor(process.stdout, 0, -1);
+          clearLine(process.stdout, 0);
         }
       };
 
       const minifyFile = (fullPath: string, outputFilePath: string): void => {
         try {
-          const content = fs.readFileSync(fullPath, "utf-8");
+          const content = readFileSync(fullPath, "utf-8");
           const minifiedContent = JSON.stringify(JSON.parse(content));
-          fs.writeFileSync(outputFilePath, minifiedContent, "utf-8");
+          writeFileSync(outputFilePath, minifiedContent, "utf-8");
           count++;
         } catch (err) {
-          fs.copyFileSync(fullPath, outputFilePath);
+          copyFileSync(fullPath, outputFilePath);
           const error = new Error(`Failed to minify JSON file: ${fullPath}\n\t→ ${err.message}`);
           error.stack = err.stack;
           errors.push(error);
@@ -69,25 +69,26 @@ export function minifyPublicJsonFiles(): VitePlugin {
       };
 
       const minifyJsonFiles = (dir: string, outDir: string): void => {
-        const files = fs.readdirSync(dir);
+        const files = readdirSync(dir);
 
         for (const file of files) {
-          const fullPath = path.join(dir, file);
-          const outputFilePath = path.join(outDir, file);
-          const stat = fs.statSync(fullPath);
+          const fullPath = join(dir, file);
+          const outputFilePath = join(outDir, file);
+          const stat = statSync(fullPath);
 
           if (skipExcludes(file)) {
-            clearLine();
+            clearTerminalLine();
             logger.info(yellow(`Skipping "${fullPath}".`));
             continue;
           }
 
           if (stat.isDirectory()) {
-            clearLine();
+            clearTerminalLine();
             logger.info(green(`Processing directory "${fullPath}".`));
+
             // Recurse into subdirectories
-            const nestedOutputDir = path.join(outDir, file);
-            fs.mkdirSync(nestedOutputDir, { recursive: true });
+            const nestedOutputDir = join(outDir, file);
+            mkdirSync(nestedOutputDir, { recursive: true });
             minifyJsonFiles(fullPath, nestedOutputDir);
             continue;
           }
@@ -98,21 +99,21 @@ export function minifyPublicJsonFiles(): VitePlugin {
           }
 
           // Copy other files as-is
-          fs.copyFileSync(fullPath, outputFilePath);
+          copyFileSync(fullPath, outputFilePath);
         }
       };
 
       logger.info(cyan("\nBeginning JSON minification."));
-
-      const assetsDir = path.resolve("./assets");
-      const localesDir = path.resolve("./locales");
-      const outputDir = path.resolve(options.dir || "dist");
-
       if (!process.env.CI) {
         logger.info("");
       }
+
+      const assetsDir = resolve("./assets");
+      const localesDir = resolve("./locales");
+      const outputDir = resolve(options.dir || "dist");
+
       minifyJsonFiles(assetsDir, outputDir);
-      minifyJsonFiles(localesDir, path.join(outputDir, "locales"));
+      minifyJsonFiles(localesDir, join(outputDir, "locales"));
 
       logger.info(cyan("JSON minification complete."));
     },


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The issue was raised that the logging output of the JSON minify plugin was too verbose.

## What are the changes from a developer perspective?
When running the build command locally, the JSON minify plugin will reduce logging output by clearing old logs from the terminal.
Some misc code cleanup was done as well.

## Screenshots/Videos
<details><summary>Final output</summary>

<img width="825" height="57" alt="image" src="https://github.com/user-attachments/assets/26458cbd-2bba-4d7c-aa5f-7aa8049c2f6b" />

</details> 

## How to test the changes?
Run `pnpm build` and observe the output.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually