### PR TITLE
fix(beta): prevent crash when choosing wave rewards

### DIFF
--- a/src/phases/show-party-exp-bar-phase.ts
+++ b/src/phases/show-party-exp-bar-phase.ts
@@ -33,7 +33,7 @@ export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
       globalScene.phaseManager.unshiftNew("LevelUpPhase", this.partyMemberIndex, lastLevel, newLevel);
     }
     globalScene.phaseManager.unshiftNew("HidePartyExpBarPhase");
-    pokemon.updateInfo();
+    await pokemon.updateInfo();
 
     switch (settings.general.partyExpNotificationMode) {
       case ExpNotification.SKIP:
@@ -48,12 +48,7 @@ export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
         // this means if we level up
         // instead of displaying the exp gain in the small frame, we display the new level
         // we use the same method for mode 0 & 1, by giving a parameter saying to display the exp or the level
-        await globalScene.partyExpBar.showPokemonExp(
-          pokemon,
-          exp.value,
-          settings.general.partyExpNotificationMode === ExpNotification.ONLY_LEVEL_UP,
-          newLevel,
-        );
+        await globalScene.partyExpBar.showPokemonExp(pokemon, exp.value, true, newLevel);
         setTimeout(() => this.end(), 800 / Math.pow(2, settings.general.expGainsSpeed));
 
         return;
@@ -61,9 +56,7 @@ export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
         await globalScene.partyExpBar.showPokemonExp(pokemon, exp.value, false, newLevel);
         setTimeout(() => this.end(), 500 / Math.pow(2, settings.general.expGainsSpeed));
 
-        break;
+        return;
     }
-
-    this.end();
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
The game won't crash when choosing end of wave rewards with "Show Party EXP" set to "Normal".

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Replaced a `break;` statement with `return;` as it was intended to be, preventing `this.end()` from erroneously being called twice in `ShowPartyExpBarPhase`.

## How to test the changes?
Beat a wave with the "Show Party EXP" option set to "Normal".

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually