### PR TITLE
dev: suppress title stats error message when running locally

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,6 +3,7 @@ import { PokerogueAdminApi } from "#api/admin-api";
 import { ApiBase } from "#api/api-base";
 import { PokerogueDailyApi } from "#api/daily-api";
 import { PokerogueSavedataApi } from "#api/savedata-api";
+import { bypassLogin } from "#constants/app-constants";
 import type { TitleStatsResponse } from "#types/api";
 
 /** A wrapper for PokéRogue API requests. */
@@ -23,6 +24,9 @@ export class PokerogueApi extends ApiBase {
 
   /** Request game title stats. */
   public async getGameTitleStats(): Promise<TitleStatsResponse | null> {
+    if (bypassLogin) {
+      return null;
+    }
     try {
       const response = await this.doGet("/game/titlestats");
       return (await response.json()) as TitleStatsResponse;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The console spam was annoying.

## What are the changes from a developer perspective?
The API call to check the title stats (active players) is skipped if there is no server connected (e.g. when running the game offline/locally).

## How to test the changes?
Watch the devtools console and note the lack of errors when compared to beta when running locally.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually