### PR TITLE
refactor: checks for unimplemented moves won't check the name

### DIFF
--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -107,7 +107,7 @@ function getAndWeightLevelMoves(pokemon: Pokemon): Map<MoveId, number> {
     }
     const move = allMoves[id];
     // Skip unimplemented moves or moves that are already in the pool
-    if (move.name.endsWith(" (N)") || movePool.has(id)) {
+    if (move.isUnimplemented || movePool.has(id)) {
       continue;
     }
 
@@ -385,7 +385,7 @@ function filterMovePool(
       !ignoreSoftBlocklists && (noDoublesMovesInSingles || applyLevelBasedDenyList || excludeWorseOffensiveStatMoves);
     if (
       weight <= 0
-      || move.name.endsWith(" (N)") // Forbid unimplemented moves
+      || move.isUnimplemented // Forbid unimplemented moves
       || move.hasAttr("SacrificialAttrOnHit") // No one gets Memento or Final Gambit
       || (isBoss && (move.hasAttr("SacrificialAttr") || move.hasAttr("HpSplitAttr"))) // Bosses never get self ko moves or Pain Split
       || (hasTrainer && move.hasAttr("OneHitKOAttr")) // trainers never get OHKO moves

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -122,7 +122,7 @@ import type {
 } from "#types/move-types";
 import type { GetEffectiveStatParams } from "#types/pokemon-common";
 import type { TurnMove } from "#types/turn-move";
-import type { AbstractConstructor } from "#types/type-helpers";
+import type { AbstractConstructor, Mutable } from "#types/type-helpers";
 import { coerceArray } from "#utils/array";
 import { applyChallenges } from "#utils/challenge-utils";
 import {
@@ -240,6 +240,8 @@ export abstract class Move implements Localizable {
     return this._allyTargetDefault;
   }
   private nameAppend = "";
+
+  public readonly isUnimplemented: boolean = false;
 
   /**
    * Check if the move is of the given subclass without requiring `instanceof`.
@@ -631,6 +633,7 @@ export abstract class Move implements Localizable {
    */
   unimplemented(): this {
     this.nameAppend += " (N)";
+    (this as Mutable<this>).isUnimplemented = true;
     return this;
   }
 
@@ -8173,7 +8176,7 @@ abstract class CallMoveAttrWithBanlist extends CallMoveAttr {
    */
   protected isMoveAllowed(move: MoveId): boolean {
     const valid = new BooleanHolder(
-      move !== MoveId.NONE && !this.invalidMoves.has(move) && !allMoves[move].name.endsWith(" (N)"),
+      move !== MoveId.NONE && !this.invalidMoves.has(move) && !allMoves[move].isUnimplemented,
     );
     applyChallenges(ChallengeType.POKEMON_MOVE, move, valid);
     return valid.value;

--- a/src/data/moves/pokemon-move.ts
+++ b/src/data/moves/pokemon-move.ts
@@ -59,7 +59,7 @@ export class PokemonMove {
     const moveName = move.name;
 
     // TODO: Add Sky Drop's 1 turn stall
-    if (this.moveId === MoveId.NONE || move.name.endsWith(" (N)")) {
+    if (this.moveId === MoveId.NONE || move.isUnimplemented) {
       return [false, i18next.t("battle:moveNotImplemented", { moveName: moveName.replace(" (N)", "") })];
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6760,7 +6760,7 @@ export class EnemyPokemon extends Pokemon {
               }
               // If this move is unimplemented, or the move is known to fail when used, set its target score to -20
               if (
-                (move.name.endsWith(" (N)") || !move.applyConditions(this, target, -1))
+                (move.isUnimplemented || !move.applyConditions(this, target, -1))
                 && ![MoveId.SUCKER_PUNCH, MoveId.UPPER_HAND, MoveId.THUNDERCLAP].includes(move.id)
               ) {
                 targetScore = -20;

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1509,7 +1509,7 @@ class TmModifierTypeGenerator extends ModifierTypeGenerator {
       const tierUniqueCompatibleTms = partyMemberCompatibleTms
         .flat()
         .filter(tm => tmPoolTiers[tm] === tier)
-        .filter(tm => !allMoves[tm].name.endsWith(" (N)"))
+        .filter(tm => !allMoves[tm].isUnimplemented)
         .filter((tm, i, array) => array.indexOf(tm) === i);
       if (tierUniqueCompatibleTms.length === 0) {
         return null;

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -44,7 +44,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
     const move = allMoves[this.moveId];
     const currentMoveset = pokemon.getMoveset();
 
-    if (move.name.endsWith(" (N)")) {
+    if (move.isUnimplemented) {
       this.end();
       return;
     }

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -431,7 +431,7 @@ export class MovePhase extends PokemonPhase {
     const moveName = move.getName();
     let failedText: string | undefined;
     const usability = new BooleanHolder(false);
-    if (moveName.endsWith(" (N)")) {
+    if (move.getMove().isUnimplemented) {
       failedText = i18next.t("battle:moveNotImplemented", { moveName: moveName.replace(" (N)", "") });
     } else if (moveId === MoveId.NONE || this.targets.length === 0) {
       this.cancel();

--- a/test/tests/ai/ai-moveset-gen.test.ts
+++ b/test/tests/ai/ai-moveset-gen.test.ts
@@ -205,7 +205,7 @@ describe("Unit Tests - ai-moveset-gen.ts", () => {
           [1, MoveId.TACKLE, LearnableMoveSource.OTHER],
           [5, MoveId.GROWL, LearnableMoveSource.OTHER],
         ]);
-        vi.spyOn(allMoves[MoveId.TACKLE], "name", "get").mockReturnValue("Tackle (N)");
+        vi.spyOn(allMoves[MoveId.TACKLE], "isUnimplemented", "get").mockReturnValue(true);
         const result = getAndWeightLevelMoves(pokemon);
         expect(result).not.toHaveKey(MoveId.TACKLE);
         expect(result).toHaveKey(MoveId.GROWL);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

(Probably, small chance for performance improvements or something).

## Why am I making these changes?
Checking if the name ends in "(N)" to see if the move is unimplemented is dumb.

## What are the changes from a developer perspective?
Added an `isUnimplemented` field to the `Move` class that's checked to see if a move is unimplemented instead of checking the move's name.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary