### PR TITLE
fix(ability): Liquid Ooze now bypasses fainting

### DIFF
--- a/src/data/abilities/init-abilities.ts
+++ b/src/data/abilities/init-abilities.ts
@@ -539,6 +539,7 @@ export function initAbilities() {
       .build(),
     new AbBuilder(AbilityId.LIQUID_OOZE, 3) //
       .attr(ReverseDrainAbAttr)
+      .bypassFaint()
       .build(),
     new AbBuilder(AbilityId.OVERGROW, 3) //
       .attr(LowHpMoveTypePowerBoostAbAttr, PokemonType.GRASS)


### PR DESCRIPTION
## What are the changes the user will see?
Liquid ooze now reverses the draining of attacks that kill the ability holder
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes bug
## What are the changes from a developer perspective?
Added a single flag
## Screenshots/Videos
N/A
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
