### PR TITLE
dev: run unapplied same-version system data migrators

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -1,13 +1,13 @@
 /**
  * `true` if running in "development" mode which happens when:
- * - The build mode is "development" (`pnpm build:dev` which runs `vite build --mode development`) or
+ * - The build mode is "development" (`pnpm build:dev` which runs `vite build --mode development`), or
  * - The Vite server is started via `pnpm start:dev` (which runs `vite --mode development`)
  */
 export const isDev = import.meta.env.MODE === "development";
 
 /**
  * `true` if running in "beta" mode which happens when:
- * - The build mode is "beta" (`pnpm build:beta` which runs `vite build --mode beta`) or
+ * - The build mode is "beta" (`pnpm build:beta` which runs `vite build --mode beta`), or
  * - The Vite server is started via `pnpm start:beta` (which runs `vite --mode beta`)
  */
 export const isBeta = import.meta.env.MODE === "beta";
@@ -17,6 +17,13 @@ export const isApp = import.meta.env.MODE === "app";
 
 /** `true` if running automated tests via Vitest. */
 export const IS_TEST = import.meta.env.MODE === "test";
+
+/**
+ * `true` if running in "production" mode which happens when:
+ * - The build mode is "production" (`pnpm build` which runs `vite build`), or
+ * - The Vite server is started via `pnpm start:prod` (which runs `vite --mode production`)
+ */
+export const IS_PROD = import.meta.env.MODE === "production";
 
 export const bypassLogin = import.meta.env.VITE_BYPASS_LOGIN === "1";
 

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/performance/noNamespaceImport: Convenience (there's no need to worry about tree-shaking/etc here)
 
+import { isBeta, isDev } from "#constants/app-constants";
 import { GameDataType } from "#enums/game-data-type";
 import { version } from "#package.json";
 import { SessionMigrationError } from "#system/migration-errors";
@@ -120,7 +121,7 @@ sortMigrators(settingsMigrators);
 
 /**
  * Converts incoming {@linkcode SystemSaveData} that has a version below the
- * current version number listed in `package.json`.
+ * current version number listed in `package.json` (or equal, on beta and dev instances).
  *
  * Note that no transforms act on the {@linkcode data} if its version matches
  * the current version or if there are no migrations made between its version up
@@ -129,11 +130,28 @@ sortMigrators(settingsMigrators);
  */
 export function applySystemVersionMigration(data: SystemSaveData): void {
   const prevVersion = data.gameVersion;
-  const isCurrentVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === -1;
+  /*
+   * Unlike other migrators, system save migrators can run on same-version saves
+   * if the migrator hasn't been applied yet, on beta and dev instances.
+   * This is done because migrators can be added over time while the client version stays the same,
+   * whereas on main all migrators are added at once with a version increase.
+   * Therefore, this checks that the current version is equal to or greater than the save's version,
+   * instead of only checking that the current version is greater.
+   *
+   * Main will still only run migrators on saves that are older than the current version.
+   */
+  const isPreviousVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === 1;
 
-  if (isCurrentVersionHigher) {
+  if (!isPreviousVersionHigher) {
+    const numPrevMigratorsApplied = Object.keys(data.appliedMigrators).length;
+
     applyMigrators(systemMigrators, data, prevVersion);
-    console.log(`System data successfully migrated to v${LATEST_VERSION}!`);
+
+    if (Object.keys(data.appliedMigrators).length > numPrevMigratorsApplied) {
+      console.log(`System data successfully migrated to v${LATEST_VERSION}!`);
+    } else {
+      console.log("No system data migrators applied.");
+    }
   }
 }
 
@@ -171,6 +189,7 @@ export function applySessionVersionMigration(data: Record<string, unknown>): voi
     }
 
     applyMigrators(sessionMigrators, data, prevVersion);
+
     console.log(`Session data successfully migrated to v${LATEST_VERSION}!`);
   }
 }
@@ -195,8 +214,10 @@ export function applySettingsVersionMigration(data: object): void {
 
   if (isCurrentVersionHigher) {
     applyMigrators(settingsMigrators, data, prevVersion);
+
     data["meta"]["gameVersion"] = LATEST_VERSION;
     localStorage.setItem(getDataTypeKey(GameDataType.SETTINGS), JSON.stringify(data));
+
     console.log(`Settings successfully migrated to v${LATEST_VERSION}!`);
   }
 }
@@ -219,14 +240,28 @@ function sortMigrators(migrators: SaveMigrator[]): void {
 function applyMigrators(migrators: readonly SaveMigrator[], data: SaveData, saveVersion: string): void {
   for (const migrator of migrators) {
     const isMigratorVersionHigher = compareVersions(saveVersion, migrator.version) === -1;
+    const migratorNameVersion = `${migrator.version}-${migrator.name}`;
 
     if (isMigratorVersionHigher) {
       migrator.migrate(data as any);
 
       if ("appliedMigrators" in data) {
-        const migratorNameVersion = `${migrator.version}-${migrator.name}`;
         (data.appliedMigrators as AppliedMigrators)[migratorNameVersion] = Date.now();
       }
+
+      continue;
+    }
+
+    if (
+      (isBeta || isDev) // exclude main just in case
+      && saveVersion === migrator.version
+      && "appliedMigrators" in data
+      && !(data["appliedMigrators"] as AppliedMigrators)[migratorNameVersion]
+    ) {
+      migrator.migrate(data as any);
+
+      (data.appliedMigrators as AppliedMigrators)[migratorNameVersion] = Date.now();
+      console.log(`Applied same version migrator "${migrator.name}".`);
     }
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
This should allow players on the beta server (and devs testing locally) to have system save migrators applied even if the version can't be updated when adding a new system save migrator.

## What are the changes from a developer perspective?
For system save migrators, if the migrator version is the same as the current client version and the migrator hasn't been applied yet, apply the migrator and add it to the list of applied migrators.

Main is explicitly excluded from being able to apply same-version migrators.

This does not currently apply to session or settings migrators due to them not having an `appliedMigrators` field at this time.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually