### PR TITLE
feat: add more custom daily options part 4

### DIFF
--- a/src/@types/daily-run.ts
+++ b/src/@types/daily-run.ts
@@ -111,11 +111,21 @@ export interface DailyEventMysteryEncounter {
  * When updating this interface, also update:
  * - `src/data/daily-seed/schema.json`
  */
-export interface ForcedBiome {
-  waveIndex: 10 | 20 | 30 | 40;
-  /** One or more biomes to force at the end of the specified wave index */
-  biomeId: BiomeId[];
-}
+export type ForcedBiome =
+  | {
+      waveIndex: 10 | 20 | 30 | 40;
+      /** One or more biomes to force at the end of the specified wave index */
+      biomeId: BiomeId[];
+      /** Whether all map options should be available at the end of the specified wave index */
+      allMapOptions?: never;
+    }
+  | {
+      waveIndex: 10 | 20 | 30 | 40;
+      /** One or more biomes to force at the end of the specified wave index */
+      biomeId?: never;
+      /** Whether all map options should be available at the end of the specified wave index */
+      allMapOptions: true;
+    };
 
 /**
  * Configuration for a custom daily run seed.

--- a/src/@types/daily-run.ts
+++ b/src/@types/daily-run.ts
@@ -1,3 +1,4 @@
+import type { Gender } from "#data/gender";
 import type { AbilityId } from "#enums/ability-id";
 import type { BiomeId } from "#enums/biome-id";
 import type { BiomePoolTier } from "#enums/biome-pool-tier";
@@ -23,6 +24,7 @@ export interface DailySeedStarter {
   nature?: Nature | undefined;
   ability?: AbilityId | undefined;
   passive?: AbilityId | undefined;
+  gender?: Gender | undefined;
 }
 
 export type DailySeedStarterTuple = TupleRange<1, 6, DailySeedStarter>;

--- a/src/@types/daily-run.ts
+++ b/src/@types/daily-run.ts
@@ -106,6 +106,18 @@ export interface DailyEventMysteryEncounter {
 }
 
 /**
+ * Configuration for a custom daily run forced biome.
+ * @privateRemarks
+ * When updating this interface, also update:
+ * - `src/data/daily-seed/schema.json`
+ */
+export interface ForcedBiome {
+  waveIndex: 10 | 20 | 30 | 40;
+  /** One or more biomes to force at the end of the specified wave index */
+  biomeId: BiomeId[];
+}
+
+/**
  * Configuration for a custom daily run seed.
  * @privateRemarks
  * When updating this interface, also update:
@@ -121,6 +133,7 @@ export interface CustomDailyRunConfig {
   trainerManipulations?: DailyTrainerManipulation[] | undefined;
   challenges?: DailyEventChallenge[] | undefined;
   mysteryEncounters?: DailyEventMysteryEncounter[] | undefined;
+  forcedBiomes?: ForcedBiome[] | undefined;
   /** The actual seed used for the daily run. */
   seed: string;
 }
@@ -138,5 +151,6 @@ export interface SerializedDailyRunConfig {
   trainerManipulations?: DailyTrainerManipulation[] | undefined;
   challenges?: DailyEventChallenge[] | undefined;
   mysteryEncounters?: DailyEventMysteryEncounter[] | undefined;
+  forcedBiomes?: ForcedBiome[] | undefined;
   seed: string;
 }

--- a/src/@types/daily-run.ts
+++ b/src/@types/daily-run.ts
@@ -16,16 +16,29 @@ import type { TupleRange } from "./type-helpers";
  * When updating this interface, also update:
  * - `src/data/daily-seed/schema.json`
  */
-export interface DailySeedStarter {
+interface DailySeedStarterBase {
   speciesId: SpeciesId;
   formIndex?: number | undefined;
   variant?: Variant | undefined;
   moveset?: StarterMoveset | undefined;
   nature?: Nature | undefined;
-  ability?: AbilityId | undefined;
   passive?: AbilityId | undefined;
   gender?: Gender | undefined;
 }
+
+export type DailySeedStarter = DailySeedStarterBase &
+  (
+    | {
+        /** Any ability, including one the species cannot normally have. */
+        ability?: AbilityId | undefined;
+        abilityIndex?: never;
+      }
+    | {
+        ability?: never;
+        /** The species ability slot to use. */
+        abilityIndex?: number | undefined;
+      }
+  );
 
 export type DailySeedStarterTuple = TupleRange<1, 6, DailySeedStarter>;
 

--- a/src/@types/daily-run.ts
+++ b/src/@types/daily-run.ts
@@ -126,7 +126,7 @@ export interface DailyEventMysteryEncounter {
  * When updating this interface, also update:
  * - `src/data/daily-seed/schema.json`
  */
-export type ForcedBiome =
+export type DailyForcedBiome =
   | {
       waveIndex: 10 | 20 | 30 | 40;
       /** One or more biomes to force at the end of the specified wave index */
@@ -158,7 +158,7 @@ export interface CustomDailyRunConfig {
   trainerManipulations?: DailyTrainerManipulation[] | undefined;
   challenges?: DailyEventChallenge[] | undefined;
   mysteryEncounters?: DailyEventMysteryEncounter[] | undefined;
-  forcedBiomes?: ForcedBiome[] | undefined;
+  forcedBiomes?: DailyForcedBiome[] | undefined;
   /** The actual seed used for the daily run. */
   seed: string;
 }
@@ -176,6 +176,6 @@ export interface SerializedDailyRunConfig {
   trainerManipulations?: DailyTrainerManipulation[] | undefined;
   challenges?: DailyEventChallenge[] | undefined;
   mysteryEncounters?: DailyEventMysteryEncounter[] | undefined;
-  forcedBiomes?: ForcedBiome[] | undefined;
+  forcedBiomes?: DailyForcedBiome[] | undefined;
   seed: string;
 }

--- a/src/data/daily-seed/daily-run.ts
+++ b/src/data/daily-seed/daily-run.ts
@@ -367,6 +367,31 @@ export function getDailyEventSeedBiome(): BiomeId | null {
 }
 
 /**
+ * Get the forced biome(s) for the current wave in a custom daily run.
+ * @returns An array of {@linkcode BiomeId}s to force, or `null` if there is no forced biome for the current wave.
+ */
+export function getDailyForcedBiome(): BiomeId[] | null {
+  if (!isDailyEventSeed()) {
+    return null;
+  }
+
+  const forcedBiomes = globalScene.gameMode.dailyConfig?.forcedBiomes?.find(
+    b => b.waveIndex === globalScene.currentBattle.waveIndex,
+  )?.biomeId;
+
+  if (forcedBiomes == null) {
+    return null;
+  }
+
+  if (!forcedBiomes.every(b => Object.values(BiomeId).includes(b))) {
+    console.warn("Invalid biome ID(s) used for custom daily run seed forced biome:", forcedBiomes);
+    return null;
+  }
+
+  return forcedBiomes;
+}
+
+/**
  * Sets a custom luck value for the daily run if specified in the config.
  * @see {@linkcode CustomDailyRunConfig}
  * @returns The custom luck value or `null` if there is no luck property.

--- a/src/data/daily-seed/daily-run.ts
+++ b/src/data/daily-seed/daily-run.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { dailyBiomeWeights } from "#balance/daily-biome-weights";
 import { allChallenges } from "#data/challenge";
+import { allBiomes } from "#data/data-lists";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { BiomeId } from "#enums/biome-id";
 import type { BiomePoolTier } from "#enums/biome-pool-tier";
@@ -370,14 +371,18 @@ export function getDailyEventSeedBiome(): BiomeId | null {
  * Get the forced biome(s) for the current wave in a custom daily run.
  * @returns An array of {@linkcode BiomeId}s to force, or `null` if there is no forced biome for the current wave.
  */
-export function getDailyForcedBiome(): BiomeId[] | null {
+export function getDailyForcedBiomes(): BiomeId[] | null {
   if (!isDailyEventSeed()) {
     return null;
   }
 
-  const forcedBiomes = globalScene.gameMode.dailyConfig?.forcedBiomes?.find(
+  const { biomeLinks } = allBiomes.get(globalScene.arena.biomeId);
+  const waveConfig = globalScene.gameMode.dailyConfig?.forcedBiomes?.find(
     b => b.waveIndex === globalScene.currentBattle.waveIndex,
-  )?.biomeId;
+  );
+
+  const mapBiomes = biomeLinks.map(b => (Array.isArray(b) ? b[0] : b));
+  const forcedBiomes = waveConfig?.allMapOptions ? mapBiomes : waveConfig?.biomeId;
 
   if (forcedBiomes == null) {
     return null;

--- a/src/data/daily-seed/daily-seed-utils.ts
+++ b/src/data/daily-seed/daily-seed-utils.ts
@@ -217,7 +217,7 @@ export function getDailyRunStarter(species: PokemonSpecies, config?: DailySeedSt
     startingLevel,
     undefined,
     config?.formIndex,
-    undefined,
+    config?.gender,
     isShiny,
     config?.variant,
     undefined,

--- a/src/data/daily-seed/daily-seed-utils.ts
+++ b/src/data/daily-seed/daily-seed-utils.ts
@@ -215,7 +215,7 @@ export function getDailyRunStarter(species: PokemonSpecies, config?: DailySeedSt
   const pokemon = globalScene.addPlayerPokemon(
     species,
     startingLevel,
-    undefined,
+    config?.abilityIndex,
     config?.formIndex,
     config?.gender,
     isShiny,

--- a/src/data/daily-seed/daily-seed-utils.ts
+++ b/src/data/daily-seed/daily-seed-utils.ts
@@ -68,7 +68,7 @@ export function getSerializedDailyRunConfig(): SerializedDailyRunConfig | undefi
     return;
   }
 
-  const { seed, boss, luck, forcedWaves, trainerManipulations, challenges, mysteryEncounters } =
+  const { seed, boss, luck, forcedWaves, trainerManipulations, challenges, mysteryEncounters, forcedBiomes } =
     globalScene.gameMode.dailyConfig;
   return {
     seed,
@@ -78,6 +78,7 @@ export function getSerializedDailyRunConfig(): SerializedDailyRunConfig | undefi
     trainerManipulations,
     challenges,
     mysteryEncounters,
+    forcedBiomes,
   } satisfies SerializedDailyRunConfig;
 }
 

--- a/src/data/daily-seed/schema.json
+++ b/src/data/daily-seed/schema.json
@@ -253,9 +253,26 @@
             "minimum": 0
           },
           "minItems": 1
+        },
+        "allMapOptions": {
+          "type": "boolean"
         }
       },
-      "required": ["waveIndex", "biomeId"],
+      "required": ["waveIndex"],
+      "oneOf": [
+        {
+          "required": ["biomeId"],
+          "not": {
+            "required": ["allMapOptions"]
+          }
+        },
+        {
+          "required": ["allMapOptions"],
+          "not": {
+            "required": ["biomeId"]
+          }
+        }
+      ],
       "additionalProperties": false
     }
   },

--- a/src/data/daily-seed/schema.json
+++ b/src/data/daily-seed/schema.json
@@ -27,6 +27,9 @@
           "ability": {
             "$ref": "#/$defs/ability"
           },
+          "abilityIndex": {
+            "$ref": "#/$defs/abilityIndex"
+          },
           "passive": {
             "$ref": "#/$defs/passive"
           },
@@ -35,6 +38,9 @@
             "minimum": -1,
             "maximum": 1
           }
+        },
+        "not": {
+          "required": ["ability", "abilityIndex"]
         },
         "required": ["speciesId"],
         "additionalProperties": false
@@ -148,6 +154,11 @@
     "ability": {
       "type": "integer",
       "exclusiveMinimum": 0
+    },
+    "abilityIndex": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2
     },
     "passive": {
       "type": "integer",

--- a/src/data/daily-seed/schema.json
+++ b/src/data/daily-seed/schema.json
@@ -110,6 +110,12 @@
         "$ref": "#/$defs/mysteryEncounter"
       }
     },
+    "forcedBiomes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/forcedBiome"
+      }
+    },
     "seed": {
       "type": "string"
     },
@@ -231,6 +237,25 @@
         }
       },
       "required": ["waveIndex", "type"],
+      "additionalProperties": false
+    },
+    "forcedBiome": {
+      "type": "object",
+      "properties": {
+        "waveIndex": {
+          "type": "integer",
+          "enum": [10, 20, 30, 40]
+        },
+        "biomeId": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["waveIndex", "biomeId"],
       "additionalProperties": false
     }
   },

--- a/src/data/daily-seed/schema.json
+++ b/src/data/daily-seed/schema.json
@@ -29,6 +29,11 @@
           },
           "passive": {
             "$ref": "#/$defs/passive"
+          },
+          "gender": {
+            "type": "integer",
+            "minimum": -1,
+            "maximum": 1
           }
         },
         "required": ["speciesId"],

--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { getDailyForcedBiome } from "#data/daily-seed/daily-run";
 import { allBiomes } from "#data/data-lists";
 import { BiomeId } from "#enums/biome-id";
 import { ChallengeType } from "#enums/challenge-type";
@@ -32,16 +33,23 @@ export class SelectBiomePhase extends BattlePhase {
       return;
     }
 
+    const forcedBiomes = getDailyForcedBiome();
+    if (forcedBiomes != null && forcedBiomes.length === 1) {
+      this.setNextBiomeAndEnd(forcedBiomes[0]);
+      return;
+    }
+
     if (gameMode.hasRandomBiomes) {
       this.setNextBiomeAndEnd(this.generateNextBiome(nextWaveIndex));
       return;
     }
 
     const { biomeLinks } = allBiomes.get(currentBiome);
-    if (biomeLinks.length > 1) {
-      const biomes: BiomeId[] = biomeLinks
-        .filter(b => !Array.isArray(b) || !randSeedInt(b[1]))
-        .map(b => (Array.isArray(b) ? b[0] : b));
+    if (biomeLinks.length > 1 || (forcedBiomes != null && forcedBiomes.length > 1)) {
+      const biomes: BiomeId[] =
+        forcedBiomes != null && forcedBiomes.length > 1
+          ? forcedBiomes
+          : biomeLinks.filter(b => !Array.isArray(b) || !randSeedInt(b[1])).map(b => (Array.isArray(b) ? b[0] : b));
 
       if (biomes.length > 1 && globalScene.findModifier(m => m instanceof MapModifier)) {
         const biomeSelectItems = biomes.map(b => {

--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { getDailyForcedBiome } from "#data/daily-seed/daily-run";
+import { getDailyForcedBiomes } from "#data/daily-seed/daily-run";
 import { allBiomes } from "#data/data-lists";
 import { BiomeId } from "#enums/biome-id";
 import { ChallengeType } from "#enums/challenge-type";
@@ -33,7 +33,7 @@ export class SelectBiomePhase extends BattlePhase {
       return;
     }
 
-    const forcedBiomes = getDailyForcedBiome();
+    const forcedBiomes = getDailyForcedBiomes();
     if (forcedBiomes != null && forcedBiomes.length === 1) {
       this.setNextBiomeAndEnd(forcedBiomes[0]);
       return;


### PR DESCRIPTION
## What are the changes the user will see?

more custom daily seed options
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->
> [!CAUTION]
> If you don't want to be spoilered don't check this PR. If you do see this, please DO NOT spoil it for others and keep it to yourself .
> Also counts for you Kes. Turn away!

## Why am I making these changes?

more options

## What are the changes from a developer perspective?

- added the option to set abilityindex (compared to the `ability` option this one changes on evolution)
- added the option to set starter gender
- added the options to force biomes. Either by forcing a specific list of biomes or all available map biomes


## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
`pnpm dailySeed:create` and copy into overrides

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary