### PR TITLE
fix(battle): AFTER_MOVE tags lapse twice when a move is cancelled

### DIFF
--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -940,8 +940,6 @@ export class MovePhase extends PokemonPhase {
    *     to lapse on move failure/cancellation.
    *
    *     TODO: ...this seems weird.
-   * - Lapses `AFTER_MOVE` tags:
-   *   - This handles the effects of {@linkcode MoveId.SUBSTITUTE | Substitute}
    * - Removes the second turn of charge moves
    */
   protected handlePreMoveFailures(): void {
@@ -961,7 +959,6 @@ export class MovePhase extends PokemonPhase {
     pokemon.pushMoveHistory(moveHistoryEntry);
 
     pokemon.lapseTags(BattlerTagLapseType.MOVE_EFFECT);
-    pokemon.lapseTags(BattlerTagLapseType.AFTER_MOVE);
 
     // This clears out 2 turn moves after they've been used
     // TODO: Remove post move queue refactor

--- a/test/tests/moves/taunt.test.ts
+++ b/test/tests/moves/taunt.test.ts
@@ -47,4 +47,25 @@ describe("Moves - Taunt", () => {
     const move2 = playerPokemon.getLastXMoves(1)[0]!;
     expect(move2.move).toBe(MoveId.STRUGGLE);
   });
+
+  it("should only lapse once on the turn it cancels its bearer's move", async () => {
+    // The enemy outspeeds here, so Taunt lands before the player's already-queued
+    // Growl, which then fails via checkTagCancel(TAUNT) on that same turn.
+    game.override.enemySpecies(SpeciesId.REGIELEKI);
+    await game.classicMode.startBattle(SpeciesId.SHUCKLE);
+
+    const playerPokemon = game.field.getPlayerPokemon();
+
+    game.move.select(MoveId.GROWL);
+    await game.move.selectEnemyMove(MoveId.TAUNT);
+    await game.toNextTurn();
+    expect(playerPokemon.getLastXMoves(1)[0]!.result).toBe(MoveResult.FAIL);
+    expect(playerPokemon.getTag(BattlerTagType.TAUNT)?.turnCount).toBe(3);
+
+    // Subsequent turns tick down once each, as they always did
+    game.move.select(MoveId.GROWL);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.toNextTurn();
+    expect(playerPokemon.getTag(BattlerTagType.TAUNT)?.turnCount).toBe(2);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?

A Taunt applied by a faster opponent now runs its full 4 turns instead of 3.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

`MovePhase.handlePreMoveFailures()` lapses `AFTER_MOVE` tags, and the `MovePhase.end()` call that always follows queues a `MoveEndPhase` whose `start()` lapses them again. A cancelled move therefore lapses them twice where a successful one lapses them once.

Taunt is the only tag this reaches: it is the sole `AFTER_MOVE` tag that hits the `--turnCount` in `BattlerTag.lapse()`, while Torment, Imprison and Psycho Shift each override `lapse()` and never read the counter.

The JSDoc attributes the call to Substitute, but `handlePreMoveFailures()` is only reached from the two cancellation branches in `start()`, and both return before the `MOVE` lapse in `resolveFinalPreMoveCancellationChecks()` brings the Substitute into focus.

## What are the changes from a developer perspective?

Dropped the `pokemon.lapseTags(BattlerTagLapseType.AFTER_MOVE)` call and the JSDoc bullet describing it. The `MOVE_EFFECT` lapse above it stays. `failMove()`, the sibling failure helper in this class, already leaves `AFTER_MOVE` to `MoveEndPhase`.

## Screenshots/Videos

N/A

## How to test the changes?

`pnpm test:silent taunt`

The new case has a faster Regieleki use Taunt on a slower Shuckle whose Growl is already queued, so the Growl fails that turn. Putting the removed line back makes it fail on the Taunt counter, which reads 2 instead of 3.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
