### PR TITLE
fix(beta): use pt-BR as the Brazilian Portuguese locale key

### DIFF
--- a/src/system/supported-languages.ts
+++ b/src/system/supported-languages.ts
@@ -27,7 +27,7 @@ export const SUPPORTED_LANGUAGE_ENTRIES = {
     label: "Italiano", // Italian
     hasAllLocalizedImages: true,
   },
-  "pr-BR": {
+  "pt-BR": {
     label: "Português (BR)", // Brazilian Portuguese
     hasAllLocalizedImages: true,
   },


### PR DESCRIPTION
## What are the changes the user will see?

Brazilian Portuguese loads again. Picking "Português (BR)" in Display settings, or opening the game with a `pt-BR` browser locale, now shows the Portuguese translations instead of falling back to English.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

`SUPPORTED_LANGUAGE_ENTRIES` keys the Brazilian Portuguese entry as `pr-BR`. The locales submodule directory is `pt-BR`, and `timed-events.ts` uses `pt-BR` everywhere. `pr-BR` occurs on that one line and nowhere else.

Those keys are passed to i18next as `supportedLngs`, and `loadPath` builds `./locales/${lng}/...`. Both paths into Portuguese therefore fail: a `pt-BR` browser locale is not in `supportedLngs` and falls back to English, and picking the entry requests `./locales/pr-BR/...`, which does not exist. The `pt-BR` translations are complete, so nothing was missing except the key.

Introduced in #7533. `main` predates that refactor, so this is beta only.

## What are the changes from a developer perspective?

One key renamed. `SupportedLanguage` is derived from these keys, so its union now contains `pt-BR`, which is what the rest of the codebase already passes around.

## Screenshots/Videos

No layout change. The effect is the existing `pt-BR` files being served where English was.

## How to test the changes?

Set the language to Português (BR) in Display settings and confirm the menus are Portuguese. On `beta` they stay English.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - ~[ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary~
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - ~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~

Are there any localization additions or changes? If so:
- ~[ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository~
- ~[ ] I have contacted the Translation Team on Discord for proofreading/translation~

Does this require any additions or changes to in-game assets? If so:
- ~[ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository~
