### PR TITLE
fix(item): Fix type errors on modifier rework branch

### DIFF
--- a/src/@types/held-item-data-types.ts
+++ b/src/@types/held-item-data-types.ts
@@ -1,4 +1,4 @@
-import { type HeldItemCategoryId, HeldItemId } from "#enums/held-item-id";
+import { type HeldItemCategoryId, type HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import type { RarityTier } from "#enums/reward-tier";
 import type { Pokemon } from "#field/pokemon";
 import type { AllHeldItems } from "#items/all-held-items";
@@ -41,7 +41,7 @@ export function isHeldItemSpecs(entry: unknown): entry is HeldItemSpecs {
   return (
     typeof (entry as HeldItemSpecs).id === "number"
     && typeof (entry as HeldItemSpecs).stack === "number"
-    && (entry as HeldItemSpecs).id in HeldItemId
+    && (entry as HeldItemSpecs).id in HeldItemNames
   );
 }
 

--- a/src/@types/trainer-item-data-types.ts
+++ b/src/@types/trainer-item-data-types.ts
@@ -1,5 +1,5 @@
 import type { RarityTier } from "#enums/reward-tier";
-import { TrainerItemId } from "#enums/trainer-item-id";
+import { type TrainerItemId, TrainerItemNames } from "#enums/trainer-item-id";
 import type { AllTrainerItems } from "#items/all-trainer-items";
 import type { MarkerTrainerItem, TrainerItem } from "#items/trainer-item";
 import type { TrainerItemAttr } from "#items/trainer-item-attr";
@@ -26,7 +26,7 @@ export function isTrainerItemSpecs(entry: unknown): entry is TrainerItemSpecs {
   return (
     typeof (entry as TrainerItemSpecs).id === "number"
     && typeof (entry as TrainerItemSpecs).stack === "number"
-    && (entry as TrainerItemSpecs).id in TrainerItemId
+    && (entry as TrainerItemSpecs).id in TrainerItemNames
   );
 }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -152,6 +152,7 @@ import { applyHeldItems } from "#utils/items";
 import { getLuckString, getLuckTextTint, getPartyLuckValue } from "#utils/party";
 import { decodeNickname, getPokemonSpecies } from "#utils/pokemon-utils";
 import { capitalizeFirstLetterOnly } from "#utils/strings";
+import { ValueHolder } from "#utils/value-holder";
 import i18next from "i18next";
 import Phaser from "phaser";
 
@@ -2429,8 +2430,7 @@ export class BattleScene extends SceneBase {
    * @param target {@linkcode Pokemon} recepient in this transfer
    * @param playSound `true` to play a sound when transferring the item
    * @param transferQuantity How many items of the stack to transfer. Optional, defaults to `1`
-   * @param instant ??? (Optional)
-   * @param ignoreUpdate ??? (Optional)
+   * @param ignoreUpdate If `true`, doesn't update the item bars as part of this transfer. Optional, defaults to `false`
    * @param itemLost If `true`, treat the item's current holder as losing the item (for now, this simply enables Unburden). Default is `true`.
    * @returns `true` if the transfer was successful
    */
@@ -2443,7 +2443,7 @@ export class BattleScene extends SceneBase {
     ignoreUpdate?: boolean,
     itemLost = true,
   ): boolean {
-    const cancelled = new BooleanHolder(false);
+    const cancelled = new ValueHolder(false);
 
     if (source && source.isPlayer() !== target.isPlayer()) {
       applyAbAttrs("BlockItemTheftAbAttr", { pokemon: source, cancelled });
@@ -2461,13 +2461,16 @@ export class BattleScene extends SceneBase {
       return false;
     }
     const countTaken = Math.min(transferQuantity, itemStack, maxStackCount - matchingItemStack);
-
-    const itemSpecs = source.heldItemManager.getItemSpecs(heldItemId);
-    if (!itemSpecs) {
+    if (countTaken <= 0) {
       return false;
     }
+
+    if (source.heldItemManager.getItemSpecs(heldItemId) == null) {
+      return false;
+    }
+
     source.heldItemManager.remove(heldItemId, countTaken);
-    target.heldItemManager.add(itemSpecs);
+    target.heldItemManager.add(heldItemId, countTaken);
 
     if (source.heldItemManager.getStack(heldItemId) === 0 && itemLost) {
       applyAbAttrs("PostItemLostAbAttr", { pokemon: source });

--- a/src/items/held-item-pool.ts
+++ b/src/items/held-item-pool.ts
@@ -42,7 +42,9 @@ export function assignDailyRunStarterHeldItems(party: PlayerPokemon[]) {
         p,
         party,
       );
-      p.heldItemManager.add(item);
+      if (item) {
+        p.heldItemManager.add(item);
+      }
     }
   }
 }
@@ -148,24 +150,29 @@ function getNewHeldItemFromTieredPool(
   pool: HeldItemTieredPool,
   pokemon: Pokemon,
   upgradeCount: number,
-): HeldItemId | HeldItemSpecs {
+): HeldItemId | HeldItemSpecs | null {
   const tier = determineItemPoolTier(pool, upgradeCount);
   const tierPool = pool[tier];
 
   return getNewHeldItemFromPool(tierPool!, pokemon);
 }
 
-export function getNewVitaminHeldItem(customWeights: HeldItemWeights = {}, target?: Pokemon): HeldItemId {
+export function getNewVitaminHeldItem(): HeldItemId;
+export function getNewVitaminHeldItem(customWeights: HeldItemWeights, target?: Pokemon): HeldItemId | null;
+export function getNewVitaminHeldItem(customWeights: HeldItemWeights = {}, target?: Pokemon): HeldItemId | null {
   const items = PERMANENT_STATS.map(s => permanentStatToHeldItem[s]);
   const weights = items.map(t => (target?.heldItemManager.isMaxStack(t) ? 0 : (customWeights[t] ?? 1)));
   const pickedIndex = pickWeightedIndex(weights);
-  return pickedIndex == null ? 0 : items[pickedIndex];
+  return pickedIndex == null ? null : items[pickedIndex];
 }
 
-export function getNewBerryHeldItem(customWeights: HeldItemWeights = {}, target?: Pokemon): BerryItemId {
+export function getNewBerryHeldItem(): BerryItemId;
+export function getNewBerryHeldItem(customWeights: HeldItemWeights, target?: Pokemon): BerryItemId | null;
+export function getNewBerryHeldItem(customWeights: HeldItemWeights = {}, target?: Pokemon): BerryItemId | null {
   const berryTypes = getEnumValues(BerryType);
   const items = berryTypes.map(b => berryTypeToHeldItem[b]);
 
+  // TODO this treats `customWeights` as a boolean (weight will always be 2 or 1), probably a typo
   const weights = items.map(t =>
     target?.heldItemManager.isMaxStack(t)
       ? 0
@@ -176,7 +183,7 @@ export function getNewBerryHeldItem(customWeights: HeldItemWeights = {}, target?
   );
 
   const pickedIndex = pickWeightedIndex(weights);
-  return pickedIndex == null ? 0 : items[pickedIndex];
+  return pickedIndex == null ? null : items[pickedIndex];
 }
 
 export function getNewAttackTypeBoosterHeldItem(
@@ -214,7 +221,7 @@ export function getNewAttackTypeBoosterHeldItem(
   );
 
   const pickedIndex = pickWeightedIndex(weights);
-  return pickedIndex == null ? 0 : attackTypeToHeldItem[types[pickedIndex]];
+  return pickedIndex == null ? null : attackTypeToHeldItem[types[pickedIndex]];
 }
 
 export function getNewHeldItemFromCategory(
@@ -253,12 +260,16 @@ function getPoolWeights(pool: HeldItemPool, pokemon: Pokemon): number[] {
   });
 }
 
-function getNewHeldItemFromPool(pool: HeldItemPool, pokemon: Pokemon, party?: Pokemon[]): HeldItemId | HeldItemSpecs {
+function getNewHeldItemFromPool(
+  pool: HeldItemPool,
+  pokemon: Pokemon,
+  party?: Pokemon[],
+): HeldItemId | HeldItemSpecs | null {
   const weights = getPoolWeights(pool, pokemon);
 
   const pickedIndex = pickWeightedIndex(weights);
   if (pickedIndex == null) {
-    return 0;
+    return null;
   }
   const entry = pool[pickedIndex].entry;
 

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -47,6 +47,15 @@ export abstract class HeldItemBase {
     return `${HeldItemNames[this.type]?.toLowerCase()}`;
   }
 
+  /**
+   * The name of the sound effect played when this item is obtained or transferred.
+   * @defaultValue `"se/restore"`
+   * @todo As far as I can tell this was the "default" sfx before, but we should check and decide if that should be the case
+   */
+  public get soundName(): string {
+    return "se/restore";
+  }
+
   constructor(type: HeldItemId, maxStackCount = 1) {
     this.type = type;
     this.maxStackCount = maxStackCount;

--- a/src/items/held-items/item-steal.ts
+++ b/src/items/held-items/item-steal.ts
@@ -69,6 +69,10 @@ abstract class ItemTransferHeldItemAttr<T extends HeldItemEffect> extends HeldIt
 export class TurnEndItemStealHeldItemAttr extends ItemTransferHeldItemAttr<typeof HeldItemEffect.TURN_END_ITEM_STEAL> {
   public override readonly effect = HeldItemEffect.TURN_END_ITEM_STEAL;
 
+  public override shouldApply({ pokemon }: ItemStealParams): boolean {
+    return !pokemon.isFainted();
+  }
+
   /**
    * Determines the targets to transfer items from when this applies.
    * @param pokemon the {@linkcode Pokemon} holding this item

--- a/src/items/reward.ts
+++ b/src/items/reward.ts
@@ -55,7 +55,7 @@ export abstract class Reward {
   // TODO: This is set inconsistently across classes and is only really used for category checks
   public id: RewardId;
   private readonly localeKey: string;
-  public readonly iconName: string;
+  private readonly _iconName: string;
   public group: string; // TODO: Make a union type of all groups
   public readonly soundName: string;
   public tier: RarityTier;
@@ -64,7 +64,7 @@ export abstract class Reward {
   // TODO: Move `id` into the constructor instead of assigning it in subclasses
   constructor(localeKey: string | null, iconName: string | null, group?: string, soundName = "se/restore") {
     this.localeKey = localeKey!;
-    this.iconName = iconName!;
+    this._iconName = iconName!;
     this.group = group!;
     this.soundName = soundName;
   }
@@ -75,6 +75,10 @@ export abstract class Reward {
 
   public get description(): string {
     return i18next.t(`${this.localeKey}.description`);
+  }
+
+  public get iconName(): string {
+    return this._iconName;
   }
 
   // TODO: Should this be abstract?

--- a/src/items/rewards/form-change.ts
+++ b/src/items/rewards/form-change.ts
@@ -1,8 +1,10 @@
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { allHeldItems } from "#data/data-lists";
 import { SpeciesFormChangeItemTrigger } from "#data/form-change-triggers";
-import { pokemonFormChanges, SpeciesFormChangeCondition } from "#data/pokemon-forms";
+import { SpeciesFormChangeCondition } from "#data/pokemon-forms";
 import { FormChangeItemId } from "#enums/form-change-item-id";
+import { HeldItemCategoryId, isItemInCategory } from "#enums/held-item-id";
 import { RewardId } from "#enums/reward-id";
 import { SpeciesFormKey } from "#enums/species-form-key";
 import { SpeciesId } from "#enums/species-id";
@@ -22,8 +24,9 @@ export class FormChangeItemReward extends PokemonReward {
     super("", allHeldItems[formChangeItem].iconName, (pokemon: PlayerPokemon) => {
       // Make sure the Pokemon has alternate forms
       if (
-        Object.hasOwn(pokemonFormChanges, pokemon.species.speciesId) // Get all form changes for this species with an item trigger, including any compound triggers
-        && pokemonFormChanges[pokemon.species.speciesId]
+        speciesDataRegistry.hasFormChanges(pokemon.species.speciesId) // Get all form changes for this species with an item trigger, including any compound triggers
+        && speciesDataRegistry
+          .getFormChanges(pokemon.species.speciesId)
           .filter(
             fc => fc.trigger.hasTriggerType(SpeciesFormChangeItemTrigger) && fc.preFormKey === pokemon.getFormKey(),
           )
@@ -85,9 +88,9 @@ export class FormChangeItemRewardGenerator extends RewardGenerator {
     const formChangeItemPool = [
       ...new Set(
         party
-          .filter(p => Object.hasOwn(pokemonFormChanges, p.species.speciesId))
+          .filter(p => speciesDataRegistry.hasFormChanges(p.species.speciesId))
           .flatMap(p => {
-            const formChanges = pokemonFormChanges[p.species.speciesId];
+            const formChanges = speciesDataRegistry.getFormChanges(p.species.speciesId);
             let formChangeItemTriggers = formChanges
               .filter(
                 fc =>
@@ -109,8 +112,7 @@ export class FormChangeItemRewardGenerator extends RewardGenerator {
               let foundULTRA_Z = false;
               let foundN_LUNA = false;
               let foundN_SOLAR = false;
-              formChangeItemTriggers.forEach((fc, _i) => {
-                console.log("Checking ", fc.item);
+              formChangeItemTriggers.forEach(fc => {
                 switch (fc.item) {
                   case FormChangeItemId.ULTRANECROZIUM_Z:
                     foundULTRA_Z = true;
@@ -128,8 +130,6 @@ export class FormChangeItemRewardGenerator extends RewardGenerator {
                 formChangeItemTriggers = formChangeItemTriggers.filter(
                   fc => fc.item !== FormChangeItemId.ULTRANECROZIUM_Z,
                 );
-              } else {
-                console.log("DID NOT FIND ");
               }
             }
             return formChangeItemTriggers;
@@ -138,7 +138,12 @@ export class FormChangeItemRewardGenerator extends RewardGenerator {
     ]
       .flat()
       .flatMap(fc => fc.item)
-      .filter(i => (i && i < 100) === this.isRareFormChangeItem);
+      .filter(i =>
+        isItemInCategory(
+          i,
+          this.isRareFormChangeItem ? HeldItemCategoryId.RARE_FORM_CHANGE : HeldItemCategoryId.FORM_CHANGE,
+        ),
+      );
     // convert it into a set to remove duplicate values, which can appear when the same species with a potential form change is in the party.
 
     if (formChangeItemPool.length === 0) {

--- a/src/items/rewards/held-item-reward.ts
+++ b/src/items/rewards/held-item-reward.ts
@@ -58,13 +58,13 @@ export class HeldItemReward extends PokemonReward {
 }
 
 export class BerryRewardGenerator extends RewardGenerator {
-  override generateReward(pregenArgs?: BerryType): HeldItemReward {
+  override generateReward(pregenArgs?: BerryType): HeldItemReward | null {
     if (pregenArgs !== undefined) {
       const item = berryTypeToHeldItem[pregenArgs];
       return new HeldItemReward(item);
     }
     const item = getNewBerryHeldItem();
-    return new HeldItemReward(item);
+    return item == null ? null : new HeldItemReward(item);
   }
 }
 
@@ -87,6 +87,7 @@ export class BaseStatBoosterRewardGenerator extends RewardGenerator {
       const item = permanentStatToHeldItem[pregenArgs];
       return new HeldItemReward(item);
     }
-    return new HeldItemReward(getNewVitaminHeldItem());
+    const item = getNewVitaminHeldItem();
+    return item == null ? null : new HeldItemReward(item);
   }
 }

--- a/src/items/rewards/tm.ts
+++ b/src/items/rewards/tm.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { tmPoolTiers, tmSpecies } from "#balance/tms";
+import { tmPoolTiers } from "#balance/tm-pool-tiers";
 import { allMoves } from "#data/data-lists";
 import { LearnMoveType } from "#enums/learn-move-type";
 import type { MoveId } from "#enums/move-id";
@@ -19,10 +19,7 @@ export class TmReward extends PokemonReward {
       "",
       `tm_${PokemonType[allMoves[moveId].type].toLowerCase()}`,
       (pokemon: PlayerPokemon) => {
-        if (
-          pokemon.compatibleTms.indexOf(moveId) === -1
-          || pokemon.getMoveset().filter(m => m.moveId === moveId).length > 0
-        ) {
+        if (!pokemon.isTmCompatible(moveId, true)) {
           return PartyUiHandler.NoEffectMessage;
         }
         return null;
@@ -35,7 +32,7 @@ export class TmReward extends PokemonReward {
 
   get name(): string {
     return i18next.t("modifierType:ModifierType.TmModifierType.name", {
-      moveId: padInt(Object.keys(tmSpecies).indexOf(this.moveId.toString()) + 1, 3),
+      moveId: padInt(Object.keys(tmPoolTiers).indexOf(this.moveId.toString()) + 1, 3),
       moveName: allMoves[this.moveId].name,
     });
   }
@@ -50,8 +47,8 @@ export class TmReward extends PokemonReward {
   }
 
   /**
-   * Applies {@linkcode TmConsumable}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that should learn the TM
+   * Apply this reward, queueing a `LearnMovePhase` for the target.
+   * @param pokemon - The {@linkcode PlayerPokemon} that should learn the TM
    * @returns always `true`
    */
   apply({ pokemon }: PokemonRewardParams): boolean {
@@ -79,12 +76,7 @@ export class TmRewardGenerator extends RewardGenerator {
     }
 
     const party = globalScene.getPlayerParty();
-    const partyMemberCompatibleTms = party.map(p => {
-      const previousLevelMoves = p.getLearnableLevelMoves();
-      return (p as PlayerPokemon).compatibleTms.filter(
-        tm => !p.moveset.find(m => m.moveId === tm) && !previousLevelMoves.find(lm => lm === tm),
-      );
-    });
+    const partyMemberCompatibleTms = party.map(p => p.getCompatibleTms(true, true));
     const tierUniqueCompatibleTms = partyMemberCompatibleTms
       .flat()
       .filter(tm => tmPoolTiers[tm] === this.tier)

--- a/src/items/trainer-item-pool.ts
+++ b/src/items/trainer-item-pool.ts
@@ -17,16 +17,15 @@ function getPoolWeights(pool: TrainerItemPool, manager: TrainerItemManager): num
   });
 }
 
-export function getNewTrainerItemFromPool(pool: TrainerItemPool, manager: TrainerItemManager): TrainerItemId {
+export function getNewTrainerItemFromPool(pool: TrainerItemPool, manager: TrainerItemManager): TrainerItemId | null {
   const weights = getPoolWeights(pool, manager);
 
   const pickedIndex = pickWeightedIndex(weights);
   if (pickedIndex == null) {
-    return 0;
+    return null;
   }
-  const entry = pool[pickedIndex].entry;
 
-  return entry as TrainerItemId;
+  return pool[pickedIndex].entry;
 }
 
 export function assignEnemyBuffTokenForWave(tier: RarityTier) {
@@ -51,11 +50,16 @@ export function assignEnemyBuffTokenForWave(tier: RarityTier) {
   let candidate = getNewTrainerItemFromPool(enemyBuffTokenPool[tier], globalScene.enemyTrainerItems);
   let r = 0;
   while (
-    ++r < retryCount
+    candidate !== null
+    && ++r < retryCount
     && allTrainerItems[candidate].getMaxStackCount()
       < globalScene.enemyTrainerItems.getStack(candidate) + (r < 10 ? tierStackCount : 1)
   ) {
     candidate = getNewTrainerItemFromPool(enemyBuffTokenPool[tier], globalScene.enemyTrainerItems);
+  }
+
+  if (candidate === null) {
+    return;
   }
 
   globalScene.enemyTrainerItems.add(candidate, tierStackCount);

--- a/src/phases/show-party-exp-bar-phase.ts
+++ b/src/phases/show-party-exp-bar-phase.ts
@@ -18,7 +18,7 @@ export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
   public override start(): void {
     super.start();
 
-    const pokemon = this.getPokemon();
+    const pokemon = this.getPlayerPokemon();
     const exp = new ValueHolder(this.expValue);
     globalScene.applyPlayerItems(TrainerItemEffect.EXP_BOOSTER, { numberHolder: exp });
     exp.value = Math.floor(exp.value);

--- a/test/mocks/mocks-container/mock-text.ts
+++ b/test/mocks/mocks-container/mock-text.ts
@@ -358,4 +358,8 @@ export class MockText implements MockGameObject {
   setActive(_active: boolean): this {
     return this;
   }
+
+  setLetterSpacing(_spacing?: number | undefined): this {
+    return this;
+  }
 }

--- a/test/tests/items/mini-black-hole.test.ts
+++ b/test/tests/items/mini-black-hole.test.ts
@@ -1,7 +1,7 @@
 import { AbilityId } from "#enums/ability-id";
+import { HeldItemId } from "#enums/held-item-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { PokemonMoveAccuracyBoosterModifier } from "#modifiers/modifier";
 import { GameManager } from "#test/framework/game-manager";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -20,8 +20,8 @@ describe("Items - Mini Black Hole", () => {
     game = new GameManager(phaserGame);
     game.override
       .ability(AbilityId.NO_GUARD)
-      .startingHeldItems([{ name: "WIDE_LENS", count: 10 }])
-      .enemyHeldItems([{ name: "MINI_BLACK_HOLE" }])
+      .startingHeldItems([{ entry: HeldItemId.WIDE_LENS, count: 3 }])
+      .enemyHeldItems([{ entry: HeldItemId.MINI_BLACK_HOLE }])
       .battleStyle("single")
       .criticalHits(false)
       .enemySpecies(SpeciesId.MAGIKARP)
@@ -34,17 +34,18 @@ describe("Items - Mini Black Hole", () => {
 
     game.field.getEnemyPokemon().hp = 1;
 
-    expect(game.scene.getModifiers(PokemonMoveAccuracyBoosterModifier, true)[0].getStackCount()).toBe(10);
+    const player = game.field.getPlayerPokemon();
+    expect(player.heldItemManager.getStack(HeldItemId.WIDE_LENS)).toBe(3);
 
     game.move.use(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(game.scene.getModifiers(PokemonMoveAccuracyBoosterModifier, true)[0].getStackCount()).toBe(9);
-    expect(game.scene.getModifiers(PokemonMoveAccuracyBoosterModifier, false)[0].getStackCount()).toBe(1);
+    expect(player.heldItemManager.getStack(HeldItemId.WIDE_LENS)).toBe(2);
+    expect(game.field.getEnemyPokemon().heldItemManager.getStack(HeldItemId.WIDE_LENS)).toBe(1);
 
     game.move.use(MoveId.LEECH_SEED);
     await game.toNextWave();
 
-    expect(game.scene.getModifiers(PokemonMoveAccuracyBoosterModifier, true)[0].getStackCount()).toBe(9);
+    expect(game.field.getPlayerPokemon().heldItemManager.getStack(HeldItemId.WIDE_LENS)).toBe(2);
   });
 });


### PR DESCRIPTION

## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Errors

## What are the changes from a developer perspective?
All type errors which are *not* migrator-related have been fixed.

- Fixed mini black hole test against new item system
  - Fixed related issues where item stealing always took the entire stack, and MBH could steal when holder was fainted
- Swapped broken `in` checks on const objects (for example, `x in HeldItemId` checks against the string keys in `HeldItemId` rather than the numeric values, which was intended)
- Converted *-item-pool files from `0` as a sentinel to `null` (0 is invalid as not all item types have a 0 value)
- Converted `iconName` on the base `Reward` class to a getter rather than a property, as subclasses use this pattern and it was conflicting
- Migrated form change items to use the species data registry
- Switched the TM file to use the dedicated TM methods on `Pokemon`
- Added `se/restore` as the default for held items (need to make sure this is correct/intended, not certain)

## How to test the changes?
`pnpm typecheck`, you should only see errors in migrator-related files

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [ ] **I'm using `beta` as my base branch**
  - [ ] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [ ] I have provided a clear explanation of the changes within the PR description
  - [ ] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [ ] The PR is self-contained and cannot be split into smaller PRs
- [ ] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
