### PR TITLE
fix(move): Smelling Salts no longer cures the user's paralysis

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -10377,7 +10377,7 @@ export function initMoves() {
       .attr(MovePowerMultiplierAttr, (_user, target, _move) =>
         target.status?.effect === StatusEffect.PARALYSIS ? 2 : 1,
       )
-      .attr(HealStatusEffectAttr, true, StatusEffect.PARALYSIS),
+      .attr(HealStatusEffectAttr, false, StatusEffect.PARALYSIS),
     new SelfStatusMove(MoveId.FOLLOW_ME, PokemonType.NORMAL, -1, 20, -1, 2, 3)
       .attr(AddBattlerTagAttr, BattlerTagType.CENTER_OF_ATTENTION, true)
       .condition(failIfSingleBattle, 3),

--- a/test/tests/moves/smelling-salts.test.ts
+++ b/test/tests/moves/smelling-salts.test.ts
@@ -1,11 +1,10 @@
-import { allMoves } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/framework/game-manager";
 import Phaser from "phaser";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Smelling Salts", () => {
   let phaserGame: Phaser.Game;

--- a/test/tests/moves/smelling-salts.test.ts
+++ b/test/tests/moves/smelling-salts.test.ts
@@ -25,8 +25,6 @@ describe("Moves - Smelling Salts", () => {
       .enemyLevel(100)
       .enemyMoveset(MoveId.SPLASH)
       .enemyAbility(AbilityId.BALL_FETCH);
-
-    vi.spyOn(allMoves[MoveId.SMELLING_SALTS], "accuracy", "get").mockReturnValue(100);
   });
 
   it("should cure the target's paralysis", async () => {

--- a/test/tests/moves/smelling-salts.test.ts
+++ b/test/tests/moves/smelling-salts.test.ts
@@ -20,7 +20,6 @@ describe("Moves - Smelling Salts", () => {
     game.override
       .battleStyle("single")
       .criticalHits(false)
-      .moveset([MoveId.SMELLING_SALTS])
       .ability(AbilityId.BALL_FETCH)
       .enemySpecies(SpeciesId.SHUCKLE)
       .enemyLevel(100)
@@ -33,25 +32,27 @@ describe("Moves - Smelling Salts", () => {
   it("should cure the target's paralysis", async () => {
     game.override.enemyStatusEffect(StatusEffect.PARALYSIS);
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
     const enemy = game.field.getEnemyPokemon();
 
-    game.move.select(MoveId.SMELLING_SALTS);
+    game.move.use(MoveId.SMELLING_SALTS);
     await game.toNextTurn();
 
-    expect(enemy.status?.effect).toBeUndefined();
+    expect(enemy).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not cure the user's own paralysis", async () => {
     game.override.statusEffect(StatusEffect.PARALYSIS);
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
 
-    game.move.select(MoveId.SMELLING_SALTS);
+    game.move.use(MoveId.SMELLING_SALTS);
     await game.move.forceStatusActivation(false);
     await game.toNextTurn();
 
-    expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
-    expect(player.status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(enemy).not.toHaveFullHp();
+    expect(player).toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 });

--- a/test/tests/moves/smelling-salts.test.ts
+++ b/test/tests/moves/smelling-salts.test.ts
@@ -1,0 +1,57 @@
+import { allMoves } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
+import { GameManager } from "#test/framework/game-manager";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Smelling Salts", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({ type: Phaser.HEADLESS });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleStyle("single")
+      .criticalHits(false)
+      .moveset([MoveId.SMELLING_SALTS])
+      .ability(AbilityId.BALL_FETCH)
+      .enemySpecies(SpeciesId.SHUCKLE)
+      .enemyLevel(100)
+      .enemyMoveset(MoveId.SPLASH)
+      .enemyAbility(AbilityId.BALL_FETCH);
+
+    vi.spyOn(allMoves[MoveId.SMELLING_SALTS], "accuracy", "get").mockReturnValue(100);
+  });
+
+  it("should cure the target's paralysis", async () => {
+    game.override.enemyStatusEffect(StatusEffect.PARALYSIS);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.select(MoveId.SMELLING_SALTS);
+    await game.toNextTurn();
+
+    expect(enemy.status?.effect).toBeUndefined();
+  });
+
+  it("should not cure the user's own paralysis", async () => {
+    game.override.statusEffect(StatusEffect.PARALYSIS);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.select(MoveId.SMELLING_SALTS);
+    await game.move.forceStatusActivation(false);
+    await game.toNextTurn();
+
+    expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
+    expect(player.status?.effect).toBe(StatusEffect.PARALYSIS);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

Smelling Salts now cures the paralysis of the Pokémon it hits instead of the paralysis of the Pokémon using it. The doubled power against a paralyzed target is unchanged.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Fixes #7584, where an enemy Hariyama used Smelling Salts in a Daily Run and cleared its own paralysis.

## What are the changes from a developer perspective?

The first constructor argument of `HealStatusEffectAttr` is `selfTarget`, and `apply` picks who gets cured with `const pokemon = this.selfTarget ? user : target;`. Smelling Salts was registered with `true`, so the cure landed on the user. Wake-Up Slap, the same idea for sleep, is registered with `false`.

```diff
     new AttackMove(MoveId.SMELLING_SALTS, PokemonType.NORMAL, MoveCategory.PHYSICAL, 70, 100, 10, -1, 0, 3)
       .attr(MovePowerMultiplierAttr, (_user, target, _move) =>
         target.status?.effect === StatusEffect.PARALYSIS ? 2 : 1,
       )
-      .attr(HealStatusEffectAttr, true, StatusEffect.PARALYSIS),
+      .attr(HealStatusEffectAttr, false, StatusEffect.PARALYSIS),
```

The power multiplier three lines above already reads `target.status`, so the move was half right: it doubled its power for a paralyzed target and then cured the wrong Pokémon. Flipping the flag also fixes the fainted check in `MoveEffectAttr.canApply` and moves the effect into the target pass in `MoveEffectPhase`, both of which read the same `selfTarget`.

One thing I deliberately left alone: `HealStatusEffectAttr.getUserBenefitScore` returns `user.status ? 10 : 0`, which does not describe a cure applied to the target. Wake-Up Slap and Sparkly Swirl share that attribute and the same scoring, so it predates this bug and looks like a separate change rather than something to fold in here. Happy to open a follow-up if you want it addressed.

## Screenshots/Videos

N/A, no visual change beyond which Pokémon the existing cure message names.

## How to test the changes?

New file `test/tests/moves/smelling-salts.test.ts` with two cases, no overrides needed:

- the target's paralysis is cured
- the user's own paralysis is not

Both fail on `beta` and pass with the change. On `beta` the first reports `expected 3 to be undefined` and the second reports `expected undefined to be 3`, which is the bug from both sides.

```
pnpm test:silent test/tests/moves/smelling-salts.test.ts
```

Manual check on top of that: `pnpm typecheck` is clean, `pnpm biome:ci` reports no findings, and the full `pnpm test:silent` run is 450 files and 2995 tests passing, 7 files and 6 tests skipped, on Node 24.19 in a Linux container.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- ~~[ ] I have provided screenshots/videos of the changes (if applicable)~~
  - ~~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~~

Are there any localization additions or changes? No.

Does this require any additions or changes to in-game assets? No.

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.
