### PR TITLE
fix(graphics): tera stellar shader now renders properly once again

### DIFF
--- a/src/pipelines/glsl/sprite-frag-shader.frag
+++ b/src/pipelines/glsl/sprite-frag-shader.frag
@@ -200,7 +200,7 @@ void main() {
 		teraCol.rgb = mix(teraCol.rgb, teraColor, 0.5);
 		color.rgb = blendOverlay(color.rgb, teraCol.rgb);
 
-		if (any(lessThan(teraCol.rgb, vec3(1.0)))) {
+		if (any(lessThan(teraColor.rgb, vec3(1.0)))) {
 			vec3 teraColHsv = rgb2hsv(teraColor);
 			color.rgb = mix(color.rgb, teraColor, (1.0 - teraColHsv.g) / 2.0);
 		}


### PR DESCRIPTION
## What are the changes the user will see?
The tera stellar shader that was broken in version 1.9.0 to render improperly has been fixed.
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes #6372

## What are the changes from a developer perspective?
Fixed an incorrect use of `teraCol` instead of `teraColor` in a conditional in the `sprite-frag-shader.frag` introduced in #5668

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1593" height="660" alt="Image" src="https://github.com/user-attachments/assets/84a90249-747b-437d-a9d9-4c4db90602f2" />

</details>
<details><summary>After</summary>

<img width="1602" height="658" alt="Image" src="https://github.com/user-attachments/assets/ca0c4e29-96a3-452d-b3d1-3609d24abff7" />

</details>


## How to test the changes?
```ts
const overrides = {
  STARTING_MODIFIER_OVERRIDE: [{name: "TERA_ORB"}],
  STARTER_SPECIES_OVERRIDE: SpeciesId.TERAPAGOS,
} satisfies Partial<InstanceType<OverridesType>>;
```
Tera and then use a move and observe.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - ~~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~~