### PR TITLE
fix(ability): Sturdy now applies to moves that deal fixed damage

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3680,6 +3680,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       );
       fixedDamage.value = toDmgValue(fixedDamage.value * multiLensMultiplier.value);
 
+      // This return skips the rest of the calculation, so abilities that endure a hit
+      // taken at full HP (Sturdy) have to be given their chance to apply here too.
+      if (this.isFullHp() && !ignoreAbility) {
+        applyAbAttrs("PreDefendFullHpEndureAbAttr", {
+          pokemon: this,
+          opponent: source,
+          move,
+          simulated,
+          damage: fixedDamage,
+        });
+      }
+
       return {
         cancelled: false,
         result: HitResult.EFFECTIVE,

--- a/test/tests/abilities/sturdy.test.ts
+++ b/test/tests/abilities/sturdy.test.ts
@@ -49,6 +49,28 @@ describe("Abilities - Sturdy", () => {
     expect(enemyPokemon).toHaveFainted();
   });
 
+  it("protects from moves that deal fixed damage", async () => {
+    await game.classicMode.startBattle(SpeciesId.LUCARIO);
+    const enemyPokemon = game.field.getEnemyPokemon();
+
+    game.move.use(MoveId.SEISMIC_TOSS);
+    await game.toEndOfTurn();
+
+    expect(enemyPokemon).toHaveHp(1);
+  });
+
+  it("doesn't protect from fixed damage when user is not at full HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.LUCARIO);
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    enemyPokemon.hp = enemyPokemon.getMaxHp() - 1;
+
+    game.move.use(MoveId.SEISMIC_TOSS);
+    await game.toEndOfTurn();
+
+    expect(enemyPokemon).toHaveFainted();
+  });
+
   it("protects from OHKO moves", async () => {
     await game.classicMode.startBattle(SpeciesId.LUCARIO);
 


### PR DESCRIPTION
## What are the changes the user will see?

Sturdy now survives a hit from moves that deal fixed damage, such as Seismic Toss, Night Shade, Dragon Rage and the Counter family, the same way it already survives ordinary attacks.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Fixes #5017.

## What are the changes from a developer perspective?

Sturdy is not checked inside `Pokemon.damage()`. It works in two steps: `getAttackDamage` applies `PreDefendFullHpEndureAbAttr`, which adds the `STURDY` tag when the target is at full HP and the damage would knock it out, and `damage()` later sees that tag and holds the Pokémon at 1 HP.

The problem is that `getAttackDamage` returns early for moves with `FixedDamageAttr`, about 180 lines before the attribute is applied:

```ts
const fixedDamage = new NumberHolder(0);
applyMoveAttrs("FixedDamageAttr", source, this, move, fixedDamage);
if (fixedDamage.value) {
  // Multi Lens multiplier
  return { cancelled: false, result: HitResult.EFFECTIVE, damage: fixedDamage.value };
}
```

So the tag is never added and `damage()` has nothing to hold. The change applies the attribute in that branch too, after the Multi Lens multiplier and behind the same `this.isFullHp() && !ignoreAbility` guard used further down.

Two things that suggest this is an oversight rather than a decision. First, Endure and Focus Sash both live inside `damage()` and therefore already work against fixed damage, which matches what the issue reports. Second, Sturdy already covers OHKO moves through `BlockOneHitKOAbAttr`, so the intent is to cover knockouts generally, not to carve out fixed damage.

One correction to the issue body, which is worth stating so nobody chases it: it says Final Gambit does not bypass Sturdy. `UserHpDamageAttr` extends `FixedDamageAttr`, so it goes through the same early return. I could not measure Final Gambit, because the user faints and my test times out waiting for the switch, so I am reporting the code path rather than a measurement.

I did not touch the OHKO branch below, since `BlockOneHitKOAbAttr` already handles it and has a passing test.

## Screenshots/Videos

N/A, no visual change.

## How to test the changes?

Two cases added to `test/tests/abilities/sturdy.test.ts`, using the Aron with Sturdy against Lucario with No Guard that the file already sets up:

- `protects from moves that deal fixed damage` uses Seismic Toss and expects 1 HP. It fails on `beta`, where Aron faints.
- `doesn't protect from fixed damage when user is not at full HP` is the regression guard, so the fix cannot degrade into holding at 1 HP unconditionally. It passes before and after.

```
pnpm test:silent test/tests/abilities/sturdy.test.ts
```

I also checked Dragon Rage and Night Shade by hand with the same setup: 21 max HP, 1 HP left, no faint. They are not in the diff because they exercise the same behaviour through `FixedDamageAttr` and `LevelDamageAttr`, and the file keeps one case per behaviour.

`pnpm typecheck` and `pnpm biome:ci` are clean. The full `pnpm test:silent` run is 449 files and 2995 tests passing, 7 files and 6 tests skipped, on Node 24.19 in a Linux container. An earlier run of the same suite had two failures in `test/tests/pokemon/pokemon-sprite.test.ts`, which does not touch this change; that file passes on its own with 17 tests and the whole suite passed on the rerun, so I am reading it as a flake under load rather than something this PR caused.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- ~~[ ] I have provided screenshots/videos of the changes (if applicable)~~
  - ~~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~~

Are there any localization additions or changes? No.

Does this require any additions or changes to in-game assets? No.

Note: this is my second PR here today, after #7618. They are disjoint, #7618 touches only `src/data/moves/move.ts` and this one only `src/field/pokemon.ts`, so there is no stacking between them. Happy to hold this one if you would rather review them one at a time.

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.
