### PR TITLE
Assign vitamins by their proper ID in `allHeldItems`

### DIFF
--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -134,7 +134,7 @@ const vitaminItems = PERMANENT_STATS.reduce(
   (ret, stat) => {
     const id = permanentStatToHeldItem[stat];
     id satisfies BaseStatItemId;
-    ret[stat] = new HeldItemBuilder(id, 30) //
+    ret[id] = new HeldItemBuilder(id, 30) //
       .attr(BaseStatMultiplyHeldItemAttr, stat)
       .unstealable()
       .untransferable()


### PR DESCRIPTION
Vitamins were being assigned into `allHeldItems` by their `Stat` enum value (0-5) instead of their `BaseStatItemId` (2049-2054). This breaks them in practice because any `allHeldItems[id]`-type call will return `undefined`