### PR TITLE
fix: prevent `1.0.3` save migrator from crashing

### DIFF
--- a/src/system/version-migration/versions/v1_0_3.ts
+++ b/src/system/version-migration/versions/v1_0_3.ts
@@ -33,7 +33,9 @@ const createStarterData: SystemSaveMigrator = {
     if (data["starterMoveData"]) {
       const starterMoveData = data["starterMoveData"];
       for (const s of Object.keys(starterMoveData)) {
-        data.starterData[s].moveset = starterMoveData[s];
+        if (data.starterData[s]) {
+          data.starterData[s].moveset = starterMoveData[s];
+        }
       }
       data["starterMoveData"] = undefined;
     }
@@ -41,7 +43,9 @@ const createStarterData: SystemSaveMigrator = {
     if (data["starterEggMoveData"]) {
       const starterEggMoveData = data["starterEggMoveData"];
       for (const s of Object.keys(starterEggMoveData)) {
-        data.starterData[s].eggMoves = starterEggMoveData[s];
+        if (data.starterData[s]) {
+          data.starterData[s].eggMoves = starterEggMoveData[s];
+        }
       }
       data["starterEggMoveData"] = undefined;
     }


### PR DESCRIPTION
## What are the changes the user will see?
Pre-1.0.3 saves that had starter data for pre-evolved starters (such as Snorlax) will be able to load again.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Added nullish guards in the `1.0.3` migrator.

## How to test the changes?
Import this save on beta, then copy the changes from the PR and import it again. The former will result in a blank save, and the latter will result in the save loading properly.

[1.0.3 migrator crash decrypted.json](https://github.com/user-attachments/files/31308823/1.0.3.migrator.crash.decrypted.json)

Note that this has to be done on the beta branch because it's a decrypted save file and the ability to load those isn't on main yet.

## Checklist
- The PR content is correctly formatted:
  - ~[ ] **I'm using `beta` as my base branch**~
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually