### PR TITLE
dev: disable minification when building in dev mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,14 +45,13 @@ export const sharedConfig: UserConfigFnPromise = async ({ mode }) => {
           keepNames: true,
           // Needed to prevent import timing issues with the phaser3 rex plugins
           strictExecutionOrder: true,
-          minify: {
-            mangle: {
-              keepNames: true,
-            },
-            compress: {
-              keepNames: { class: true, function: true },
-            },
-          },
+          minify:
+            mode === "development"
+              ? "dce-only"
+              : {
+                  mangle: { keepNames: true },
+                  compress: { keepNames: { class: true, function: true } },
+                },
         },
       },
     },


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Easier to inspect the build output when testing.

## What are the changes from a developer perspective?
Minification of the build output is disabled when running `pnpm build:dev`.

## How to test the changes?
Run `pnpm build:dev` and inspect the output files.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually