### PR TITLE
misc: minor docs and type fixups

### DIFF
--- a/src/@types/error-type.ts
+++ b/src/@types/error-type.ts
@@ -1,3 +1,4 @@
+import type { Stringable } from "#types/strings";
 import type { IsAny, IsEqual, IsNever, IsUnknown, Primitive, UnionToTuple } from "type-fest";
 
 /**
@@ -8,9 +9,6 @@ export type ErrorType<Msg extends string> = Error & Msg;
 
 export type IncompatibleTypeMessage<Expected, Received> =
   `Expected to receive ${FormatType<Expected>}, but got ${FormatType<Received>} instead!`;
-
-// TODO: Use version from "#types/strings" once said file is added in random species PR
-type Stringable = string | number | bigint | boolean | null | undefined;
 
 /**
  * Internal type helper to convert 2 arbitrary types (or unions thereof) into human-readable strings
@@ -29,8 +27,8 @@ export type FormatType<T> =
         : // List multi-member unions as a list of members separated by quotes and pipes,
           // handling boolean separately to avoid splitting it up as mentioned above
           Extract<T, boolean> extends never
-          ? `'${StringifyTuple<UnionToTuple<T>, "' | '">}'`
-          : `'${StringifyTuple<[...UnionToTuple<Exclude<T, boolean>>, boolean], "' | '">}'`;
+          ? `'${StringifyTuple<UnionToTuple<T>, " | ">}'`
+          : `'${StringifyTuple<[...UnionToTuple<Exclude<T, boolean>>, boolean], " | ">}'`;
 
 /**
  * Tail-recursive helper to stringify a tuple with an arbitrary delimiter.
@@ -76,8 +74,6 @@ type PrintTypeInternal<T> =
                     ? "number"
                     : bigint extends T
                       ? "bigint"
-                      : boolean extends T
-                        ? "boolean"
-                        : T extends Stringable
-                          ? `${T}`
-                          : never;
+                      : T extends Stringable
+                        ? `${T}`
+                        : never;

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -1032,6 +1032,7 @@ export class PostReceiveCritStatStageChangeAbAttr extends AbAttr {
 export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
   private readonly damageRatio: number;
 
+  // TODO: This is a divisor, not a ratio
   constructor(damageRatio: number) {
     super();
 
@@ -4908,6 +4909,7 @@ export class PostFaintFormChangeAbAttr extends PostFaintAbAttr {
 export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
   private readonly damageRatio: number;
 
+  // TODO: This is a divisor, not a ratio
   constructor(damageRatio: number) {
     super(true);
 

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -5207,6 +5207,11 @@ export interface MoveAbilityBypassAbAttrParams extends AbAttrBaseParams {
 }
 
 export class MoveAbilityBypassAbAttr extends AbAttr {
+  /**
+   * A lambda function to determine whether a given ability should be ignored.
+   * @defaultValue `() => true` (ignores all abilities)
+   */
+  // TODO: Nothing uses the pokemon parameter; remove it?
   private readonly moveIgnoreFunc: (pokemon: Pokemon, move: Move) => boolean;
 
   constructor(moveIgnoreFunc: (pokemon: Pokemon, move: Move) => boolean = () => true) {

--- a/src/data/abilities/init-abilities.ts
+++ b/src/data/abilities/init-abilities.ts
@@ -2099,7 +2099,7 @@ export function initAbilities() {
         MovePriorityInBracket.LAST,
       )
       .attr(PreventBypassSpeedChanceAbAttr, (_pokemon, move) => move.category === MoveCategory.STATUS)
-      .attr(MoveAbilityBypassAbAttr, (_pokemon, move: Move) => move.category === MoveCategory.STATUS)
+      .attr(MoveAbilityBypassAbAttr, (_pokemon, move) => move.category === MoveCategory.STATUS)
       .build(),
     new AbBuilder(AbilityId.MINDS_EYE, 9) //
       .attr(IgnoreTypeImmunityAbAttr, PokemonType.GHOST, [PokemonType.NORMAL, PokemonType.FIGHTING])

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2202,10 +2202,12 @@ export class MessageAttr extends MoveEffectAttr {
 }
 
 export class RecoilAttr extends MoveEffectAttr {
+  /** Whether the recoil damage should be based on the user's maximum HP instead of the damage dealt. */
   private readonly useHp: boolean;
   private readonly damageRatio: number;
   private readonly unblockable: boolean;
 
+  // TODO: Make the parameter order more sensible - damage ratio required first, then the other 2 booleans
   constructor(useHp = false, damageRatio = 0.25, unblockable = false) {
     super(true, { lastHitOnly: true });
 
@@ -2219,15 +2221,14 @@ export class RecoilAttr extends MoveEffectAttr {
       return false;
     }
 
-    const cancelled = new BooleanHolder(false);
     if (!this.unblockable) {
+      const cancelled = new ValueHolder(false);
       const abAttrParams: AbAttrParamsWithCancel = { pokemon: user, cancelled };
       applyAbAttrs("BlockRecoilDamageAttr", abAttrParams);
       applyAbAttrs("BlockNonDirectDamageAbAttr", abAttrParams);
-    }
-
-    if (cancelled.value) {
-      return false;
+      if (cancelled.value) {
+        return false;
+      }
     }
 
     // Chloroblast and Struggle should not deal recoil damage if the move was not successful
@@ -2242,10 +2243,6 @@ export class RecoilAttr extends MoveEffectAttr {
     const minValue = user.turnData.totalDamageDealt ? 1 : 0;
     const recoilDamage = toDmgValue(damageValue, minValue);
     if (!recoilDamage) {
-      return false;
-    }
-
-    if (cancelled.value) {
       return false;
     }
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2271,14 +2271,6 @@ export class SacrificialAttr extends MoveEffectAttr {
     super(true, { trigger: MoveEffectTrigger.POST_TARGET });
   }
 
-  /**
-   * Deals damage to the user equal to their current hp
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args N/A
-   * @returns true if the function succeeds
-   */
   apply(user: Pokemon, _target: Pokemon, _move: Move, _args: any[]): boolean {
     user.damageAndUpdate(user.hp, { result: HitResult.INDIRECT, ignoreSegments: true });
     user.turnData.damageTaken += user.hp;
@@ -3987,6 +3979,8 @@ export class StatStageChangeAttr extends MoveEffectAttr {
     return false;
   }
 
+  // TODO: This should arguably be a lambda function set on construction (if we need the custom behavior)
+  // instead of requiring 1 subclass per type
   getLevels(_user: Pokemon): number {
     return this.stages;
   }
@@ -4354,7 +4348,16 @@ export class GrowthStatStageChangeAttr extends StatStageChangeAttr {
 }
 
 export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
+  /**
+   * A divisor for the user's maximum HP to be lost.
+   * The move will fail if less than this amount is available.
+   */
+  // TODO: Make this a % ratio
   private readonly cutRatio: number;
+  /**
+   * An optional callback function to be called after the HP loss is applied, allowing for custom messages or effects to be triggered.
+   */
+  // TODO: If this is supposed to display a message, the type should encode that information (return string instead of void)
   private readonly messageCallback: ((user: Pokemon) => void) | undefined;
 
   constructor(
@@ -4370,16 +4373,15 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
   }
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     user.damageAndUpdate(toDmgValue(user.getMaxHp() / this.cutRatio), { result: HitResult.INDIRECT });
-    user.updateInfo();
+    user.updateInfo(); // TODO: Floating promise!!!
     const ret = super.apply(user, target, move, args);
-    if (this.messageCallback) {
-      this.messageCallback(user);
-    }
+    this.messageCallback?.(user);
     return ret;
   }
 
   getCondition(): MoveConditionFunc {
-    return user => user.getHpRatio() > 1 / this.cutRatio && this.stats.some(s => user.getStatStage(s) < 6);
+    // TODO: This may not be accurate for contrary on some moves (needs confirmation)
+    return user => user.hp > user.getMaxHp() / this.cutRatio && this.stats.some(s => user.getStatStage(s) < 6);
   }
 }
 

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -7,7 +7,17 @@ export class Status {
   public effect: StatusEffect;
   /** Toxic damage is `1/16 max HP * toxicTurnCount` */
   public toxicTurnCount = 0;
+  /**
+   * The number of turns this Pokemon will remain asleep for, decremented once every time it attempts to use a move.
+   * The status will be cured once this reaches 0.
+   */
   public sleepTurnsRemaining?: number | undefined;
+  /**
+   * The number of turns this Pokemon will remain frozen for, decremented once every time it attempts to use a move.
+   * The status will be cured once this reaches 0.
+   * @remarks
+   * Freeze also has a 25% chance to thaw out at the end of each turn; this value merely upper-bounds for its duration.
+   */
   public freezeTurnsRemaining?: number | undefined;
 
   // TODO: Make this take an object?

--- a/src/phases/move-reflect-phase.ts
+++ b/src/phases/move-reflect-phase.ts
@@ -1,4 +1,5 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
+import type { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";

--- a/test/matchers/to-have-status-effect.ts
+++ b/test/matchers/to-have-status-effect.ts
@@ -11,8 +11,9 @@ import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
  * @sealed
  */
 export type PartiallyFilledStatus =
-  | { effect: StatusEffect.TOXIC; toxicTurnCount: number }
-  | { effect: StatusEffect.SLEEP; sleepTurnsRemaining: number };
+  | ({ effect: StatusEffect.TOXIC } & Pick<Status, "toxicTurnCount">)
+  | ({ effect: StatusEffect.SLEEP } & Pick<Status, "sleepTurnsRemaining">)
+  | ({ effect: StatusEffect.FREEZE } & Pick<Status, "freezeTurnsRemaining">);
 
 /**
  * Matcher that checks if a Pokemon's {@linkcode StatusEffect} is as expected

--- a/test/tests/types/value-holder.test-d.ts
+++ b/test/tests/types/value-holder.test-d.ts
@@ -50,9 +50,10 @@ describe("ValueHolder", () => {
       GetConstructErrorMsg<string, boolean>
     >().toEqualTypeOf<"Expected to receive a boolean, but got a string instead!">();
 
+    // should not distribute over union in the error message, though the order of the members may vary arbitrarily
     expectTypeOf<
       GetConstructErrorMsg<string | boolean, number>
-    >().toExtend<`Expected to receive a number, but got ${"'boolean' | 'string'" | "'string' | 'boolean'"} instead!`>();
+    >().toExtend<`Expected to receive a number, but got ${"'boolean | string'" | "'string | boolean'"} instead!`>();
 
     // union members may appear in any order, but it should be consistent across compiles
     expectTypeOf<


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Misc fixes pulled out of #7604

## What are the changes from a developer perspective?
- Added docs/TODO comments to various functions, as well as a few type imports for said docs to function
- Changed some matcher types to pick properties straight from `Status` for "Go To Definition"/etc. Also added a union arm for freeze turns remaining (was forgotten prior).
- removed a duplicated `if` check inside the recoil move code (it checked `cancelled` twice in a row)

## Screenshots/Videos
N/A
## How to test the changes?
Review the added code.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
