### PR TITLE
test: update taunt tests

### DIFF
--- a/test/tests/moves/taunt.test.ts
+++ b/test/tests/moves/taunt.test.ts
@@ -54,7 +54,7 @@ describe("Moves - Taunt", () => {
     const player = game.field.getPlayerPokemon();
 
     game.move.use(MoveId.GROWL);
-    await game.move.selectEnemyMove(MoveId.TAUNT);
+    await game.move.forceEnemyMove(MoveId.TAUNT);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
 

--- a/test/tests/moves/taunt.test.ts
+++ b/test/tests/moves/taunt.test.ts
@@ -1,4 +1,5 @@
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
@@ -20,52 +21,51 @@ describe("Moves - Taunt", () => {
     game = new GameManager(phaserGame);
     game.override
       .battleStyle("single")
+      .ability(AbilityId.BALL_FETCH)
       .enemyAbility(AbilityId.BALL_FETCH)
-      .enemyMoveset([MoveId.TAUNT, MoveId.SPLASH])
-      .enemySpecies(SpeciesId.SHUCKLE)
-      .moveset([MoveId.GROWL]);
+      .enemySpecies(SpeciesId.SHUCKLE);
   });
 
-  it("Pokemon should not be able to use Status Moves", async () => {
+  it("should prevent the target from using or selecting status moves for 4 turns", async () => {
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
 
-    const playerPokemon = game.field.getPlayerPokemon();
+    const player = game.field.getPlayerPokemon();
 
-    // First turn, Player Pokemon succeeds using Growl without Taunt
-    game.move.select(MoveId.GROWL);
-    await game.move.selectEnemyMove(MoveId.TAUNT);
+    game.move.use(MoveId.GROWL);
+    await game.move.forceEnemyMove(MoveId.TAUNT);
     await game.toNextTurn();
-    const move1 = playerPokemon.getLastXMoves(1)[0]!;
-    expect(move1.move).toBe(MoveId.GROWL);
-    expect(move1.result).toBe(MoveResult.SUCCESS);
-    expect(playerPokemon.getTag(BattlerTagType.TAUNT)).toBeDefined();
 
-    // Second turn, Taunt forces Struggle to occur
-    game.move.select(MoveId.GROWL);
-    await game.move.selectEnemyMove(MoveId.SPLASH);
-    await game.toNextTurn();
-    const move2 = playerPokemon.getLastXMoves(1)[0]!;
-    expect(move2.move).toBe(MoveId.STRUGGLE);
+    expect(player).toHaveBattlerTag({ tagType: BattlerTagType.TAUNT, turnCount: 3 });
+    expect(player.isMoveSelectable(MoveId.GROWL)[0]).toBe(false);
+    expect(player.moveset[0].isUsable(player)).toBe(false);
+
+    // since growl is the only thing in our moveset, we should be forced to use struggle
+    game.move.use(MoveId.GROWL);
+    await game.move.forceEnemyMove(MoveId.SPLASH);
+    await game.toEndOfTurn();
+
+    expect(player).toHaveUsedMove(MoveId.STRUGGLE);
   });
 
-  it("should only lapse once on the turn it cancels its bearer's move", async () => {
-    // The enemy outspeeds here, so Taunt lands before the player's already-queued
-    // Growl, which then fails via checkTagCancel(TAUNT) on that same turn.
-    game.override.enemySpecies(SpeciesId.REGIELEKI);
-    await game.classicMode.startBattle(SpeciesId.SHUCKLE);
-
-    const playerPokemon = game.field.getPlayerPokemon();
+  it("should only tick down once on the turn it cancels the target's move", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    const player = game.field.getPlayerPokemon();
 
     game.move.select(MoveId.GROWL);
     await game.move.selectEnemyMove(MoveId.TAUNT);
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
-    expect(playerPokemon.getLastXMoves(1)[0]!.result).toBe(MoveResult.FAIL);
-    expect(playerPokemon.getTag(BattlerTagType.TAUNT)?.turnCount).toBe(3);
+
+    expect(player).toHaveUsedMove({ move: MoveId.GROWL, result: MoveResult.FAIL });
+    expect(player).toHaveBattlerTag({ tagType: BattlerTagType.TAUNT, turnCount: 3 });
 
     // Subsequent turns tick down once each, as they always did
-    game.move.select(MoveId.GROWL);
-    await game.move.selectEnemyMove(MoveId.SPLASH);
-    await game.toNextTurn();
-    expect(playerPokemon.getTag(BattlerTagType.TAUNT)?.turnCount).toBe(2);
+    game.move.use(MoveId.GROWL);
+    await game.move.forceEnemyMove(MoveId.SPLASH);
+    await game.toEndOfTurn();
+
+    expect(player).toHaveBattlerTag({ tagType: BattlerTagType.TAUNT, turnCount: 2 });
   });
+
+  // TODO: Clarify behavior with Instruct
 });

--- a/test/tests/moves/taunt.test.ts
+++ b/test/tests/moves/taunt.test.ts
@@ -26,7 +26,7 @@ describe("Moves - Taunt", () => {
       .enemySpecies(SpeciesId.SHUCKLE);
   });
 
-  it("should prevent the target from using or selecting status moves for 4 turns", async () => {
+  it("should prevent the target from selecting status moves for 4 turns", async () => {
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
 
     const player = game.field.getPlayerPokemon();
@@ -35,15 +35,17 @@ describe("Moves - Taunt", () => {
     await game.move.forceEnemyMove(MoveId.TAUNT);
     await game.toNextTurn();
 
-    expect(player).toHaveBattlerTag({ tagType: BattlerTagType.TAUNT, turnCount: 3 });
+    expect(player).toHaveBattlerTag({ tagType: BattlerTagType.TAUNT, turnCount: 4 });
+
     expect(player.isMoveSelectable(MoveId.GROWL)[0]).toBe(false);
-    expect(player.moveset[0].isUsable(player)).toBe(false);
+    // TODO: Does Taunt actually make the moves unusable?
 
     // since growl is the only thing in our moveset, we should be forced to use struggle
     game.move.use(MoveId.GROWL);
     await game.move.forceEnemyMove(MoveId.SPLASH);
     await game.toEndOfTurn();
 
+    expect(player).toHaveBattlerTag({ tagType: BattlerTagType.TAUNT, turnCount: 3 });
     expect(player).toHaveUsedMove(MoveId.STRUGGLE);
   });
 
@@ -51,12 +53,12 @@ describe("Moves - Taunt", () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     const player = game.field.getPlayerPokemon();
 
-    game.move.select(MoveId.GROWL);
+    game.move.use(MoveId.GROWL);
     await game.move.selectEnemyMove(MoveId.TAUNT);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
 
-    expect(player).toHaveUsedMove({ move: MoveId.GROWL, result: MoveResult.FAIL });
+    expect(player).toHaveUsedMove({ move: MoveId.NONE, result: MoveResult.FAIL });
     expect(player).toHaveBattlerTag({ tagType: BattlerTagType.TAUNT, turnCount: 3 });
 
     // Subsequent turns tick down once each, as they always did


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
PR #7611 added tests to the taunt file.
These (being ostensibly based on the prior test file contents) did not use any of the new testing helpers that had been introduced in the months since the file was created.

## What are the changes from a developer perspective?
Rewrote the tests to use relevant helpers/matchers.
Added an explicit check that Taunt indeed does make the move unselectable.

## Screenshots/Videos
N/A
## How to test the changes?
`pnpm test:silent taunt.test.ts`
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
