### PR TITLE
refactor: Add type safety to version numbers and related code

### DIFF
--- a/src/@types/save-data.ts
+++ b/src/@types/save-data.ts
@@ -21,7 +21,11 @@ import type { VersionString } from "#types/save-migrators";
 import type { SerializedDailyRunConfig } from "./daily-run";
 import type { DexData } from "./dex-data";
 
-export type AppliedMigrators = { [key: `${VersionString}-${string}`]: number };
+/**
+ * A record tracking which migrators have been applied to the save data,
+ * timestamped by the date in Unix milliseconds.
+ */
+export type AppliedMigrators = Partial<Record<`${VersionString}-${string}`, number>>;
 
 export interface SystemSaveData {
   trainerId: number;

--- a/src/@types/save-data.ts
+++ b/src/@types/save-data.ts
@@ -17,10 +17,11 @@ import type { GameStats } from "#system/game-stats";
 import type { ModifierData } from "#system/modifier-data";
 import type { PokemonData } from "#system/pokemon-data";
 import type { TrainerData } from "#system/trainer-data";
+import type { VersionString } from "#types/save-migrators";
 import type { SerializedDailyRunConfig } from "./daily-run";
 import type { DexData } from "./dex-data";
 
-export type AppliedMigrators = { [key: string]: number };
+export type AppliedMigrators = { [key: `${VersionString}-${string}`]: number };
 
 export interface SystemSaveData {
   trainerId: number;
@@ -34,7 +35,7 @@ export interface SystemSaveData {
   voucherUnlocks: VoucherUnlocks;
   voucherCounts: VoucherCounts;
   eggs: EggData[];
-  gameVersion: string;
+  gameVersion: VersionString;
   timestamp: number;
   eggPity: number[];
   unlockPity: number[];
@@ -60,13 +61,13 @@ export interface SessionSaveData {
   battleType: Exclude<BattleType, BattleType.CLEAR>;
   // TODO: This being nullable NEEDS to be reflected in the type signature
   trainer: TrainerData;
-  gameVersion: string;
+  gameVersion: VersionString;
   /** The player-chosen name of the run */
   name: string;
   timestamp: number;
   challenges: ChallengeData[];
   // TODO: Change default value to `undefined` to both save space and ease nullishness checks
-  mysteryEncounterType: MysteryEncounterType | -1; // Only defined when current wave is ME,
+  mysteryEncounterType: MysteryEncounterType | -1; // Only defined when current wave is ME
   // TODO: This can be `undefined` - reflect that in the type signature
   mysteryEncounterSaveData: MysteryEncounterSaveData;
   /**
@@ -74,6 +75,8 @@ export interface SessionSaveData {
    */
   playerFaints: number;
 }
+
+// TODO: Make the index signatures more specific
 
 export interface Unlocks {
   [key: number]: boolean;

--- a/src/@types/save-migrators.ts
+++ b/src/@types/save-migrators.ts
@@ -1,6 +1,84 @@
 import type { PokemonData } from "#system/pokemon-data";
 import type { SessionSaveData, SystemSaveData } from "#types/save-data";
 import type { CoercePropertiesToUnknown, NonFunctionProperties } from "#types/type-helpers";
+import type { GreaterThan } from "type-fest";
+
+// #region Versioning
+
+/** A version string that predates 1.12.0. */
+type LegacyVersionString = `1.${number}.${number}`;
+/** A version string that succeeds 1.12.0. */
+type ModernVersionString = `1.${number}.${number}.${number}`;
+
+/** Type representing any arbitrary version string, either legacy or modern.*/
+export type VersionString = LegacyVersionString | ModernVersionString;
+
+/**
+ * Split a version string into its major, minor, and patch components.
+ * @typeParam T - The version string to split
+ * @returns A tuple of the form `[major, minor, patch]`.
+ */
+type SplitVersionString<T extends VersionString> =
+  T extends `1.${infer Major extends number}.${infer MinorAndMaybePatch extends number | `${number}.${number}`}`
+    ? MinorAndMaybePatch extends `${infer Minor extends number}.${infer Patch extends number}`
+      ? [Major, Minor, Patch] // modern
+      : [Major, MinorAndMaybePatch, 0] // legacy (MinorAndMaybePatch is `number`)
+    : never;
+
+/**
+ * Type to compare 2 version numbers.
+ * @returns `1` if `V1` is greater than `V2`, `-1` if `V1` is less than `V2`, or `0` if they are equal.
+ * Returns `-1 | 0 | 1` if either one is not a specific version string.
+ */
+export type CompareVersions<V1 extends VersionString, V2 extends VersionString> = [VersionString] extends [V1 | V2]
+  ? -1 | 0 | 1
+  : SplitVersionString<V1> extends [
+        infer Major1 extends number,
+        infer Minor1 extends number,
+        infer Patch1 extends number,
+      ]
+    ? SplitVersionString<V2> extends [
+        infer Major2 extends number,
+        infer Minor2 extends number,
+        infer Patch2 extends number,
+      ]
+      ? PairwiseCmp<[[Major1, Major2], [Minor1, Minor2], [Patch1, Patch2]]>
+      : never
+    : never;
+
+/**
+ * Tail-recursively compare a set of tuples, prioritizing earlier ones first.
+ */
+type PairwiseCmp<P extends readonly [number, number][]> = P extends []
+  ? 0
+  : P extends [[infer A extends number, infer B extends number], ...infer Rest extends readonly [number, number][]]
+    ? number extends A | B
+      ? -1 | 0 | 1
+      : A extends B
+        ? PairwiseCmp<Rest>
+        : GreaterThan<A, B> extends true
+          ? 1
+          : -1
+    : never;
+
+/**
+ * @returns Whether the given array of versions is sorted in non-decreasing order.
+ */
+export type AreVersionsSorted<V extends readonly VersionString[]> = V extends [] | readonly [VersionString]
+  ? true
+  : V extends readonly [
+        infer First extends VersionString,
+        infer Second extends VersionString,
+        ...infer Rest extends readonly VersionString[],
+      ]
+    ? [CompareVersions<First, Second>] extends [infer C extends -1 | 0 | 1]
+      ? C extends -1 | 0 // First <= Second
+        ? AreVersionsSorted<[Second, ...Rest]>
+        : false
+      : boolean
+    : never;
+
+// #endregion Versioning
 
 /**
  * Interface for the type of the elements of `party` and `enemyParty` properties
@@ -14,8 +92,9 @@ interface SessionSavePokemonDataIn extends CoercePropertiesToUnknown<NonFunction
  * Interface for the input data of session migrators.
  * @see {@linkcode SessionSaveMigrator}
  */
-export interface SessionSaveMigratorIn extends CoercePropertiesToUnknown<SessionSaveData> {
-  gameVersion: string;
+export interface SessionSaveMigratorIn
+  extends CoercePropertiesToUnknown<Omit<SessionSaveData, "party" | "enemyParty" | "gameVersion">>,
+    Pick<SessionSaveData, "gameVersion"> {
   /**
    * @privateRemarks
    * Due to the field's ubiquitous use in migrators,
@@ -25,26 +104,24 @@ export interface SessionSaveMigratorIn extends CoercePropertiesToUnknown<Session
   /**
    * @privateRemarks
    * Due to the field's ubiquitous use in migrators,
-   * party being an array of objects is validated prior to running any migrators.
+   * enemyParty being an array of objects is validated prior to running any migrators.
    */
   enemyParty: SessionSavePokemonDataIn[];
   [key: string]: unknown;
 }
 
-export interface SessionSaveMigrator {
-  name: string;
-  version: string;
-  migrate: (data: SessionSaveMigratorIn) => void;
+/**
+ * Interface representing an arbitrary save migrator.
+ * @typeParam Data - The type of data to be migrated
+ */
+export interface SaveMigrator<Data extends object = any> {
+  readonly name: string;
+  readonly version: VersionString;
+  readonly migrate: (data: Data) => void;
 }
 
-export interface SettingsSaveMigrator {
-  name: string;
-  version: string;
-  migrate: (data: object) => void;
-}
+export type SessionSaveMigrator = SaveMigrator<SessionSaveMigratorIn>;
 
-export interface SystemSaveMigrator {
-  name: string;
-  version: string;
-  migrate: (data: SystemSaveData) => void;
-}
+export type SettingsSaveMigrator = SaveMigrator<object>;
+
+export type SystemSaveMigrator = SaveMigrator<SystemSaveData>;

--- a/src/@types/save-migrators.ts
+++ b/src/@types/save-migrators.ts
@@ -115,8 +115,23 @@ export interface SessionSaveMigratorIn
  * @typeParam Data - The type of data to be migrated
  */
 export interface SaveMigrator<Data extends object = any> {
+  /**
+   * The name of the migrator.
+   * Should match the migrator's purpose.
+   */
   readonly name: string;
+  /**
+   * The {@linkcode VersionString} that this migrator is intended to migrate from.
+   * Should be the version immediately preceding the version that this migrator migrates to.
+   * @remarks
+   * For example, if a migrator is intended to migrate saves from before v1.5.0 to v1.5.1+,
+   * its `version` property should be `"1.5.0"`.
+   */
   readonly version: VersionString;
+  /**
+   * Migrate the given data to the next version.
+   * @param data - The data to migrate
+   */
   readonly migrate: (data: Data) => void;
 }
 

--- a/src/@types/save-migrators.ts
+++ b/src/@types/save-migrators.ts
@@ -121,10 +121,10 @@ export interface SaveMigrator<Data extends object = any> {
    */
   readonly name: string;
   /**
-   * The {@linkcode VersionString} that this migrator is intended to migrate from.
-   * Should be the version immediately preceding the version that this migrator migrates to.
+   * The {@linkcode VersionString} that this migrator is intended to migrate TO.
+   * Coincides with the game version that the migrator was introduced in.
    * @remarks
-   * For example, if a migrator is intended to migrate saves from before v1.5.0 to v1.5.1+,
+   * For example, if a migrator is intended to migrate saves due to breaking changes introduced in v1.5.0,
    * its `version` property should be `"1.5.0"`.
    */
   readonly version: VersionString;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -66,6 +66,7 @@ import type {
   VoucherCounts,
   VoucherUnlocks,
 } from "#types/save-data";
+import type { VersionString } from "#types/save-migrators";
 import type { StarterSpeciesId } from "#types/starter-species-id";
 import { RUN_HISTORY_LIMIT } from "#ui/run-history-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
@@ -161,7 +162,7 @@ export class GameData {
       voucherUnlocks: this.voucherUnlocks,
       voucherCounts: this.voucherCounts,
       eggs: this.eggs.map(e => new EggData(e)),
-      gameVersion: globalScene.game.config.gameVersion,
+      gameVersion: globalScene.game.config.gameVersion as VersionString,
       timestamp: Date.now(),
       eggPity: this.eggPity.slice(0),
       unlockPity: this.unlockPity.slice(0),
@@ -773,7 +774,7 @@ export class GameData {
         globalScene.currentBattle.battleType === BattleType.TRAINER
           ? new TrainerData(globalScene.currentBattle.trainer)
           : null,
-      gameVersion: globalScene.game.config.gameVersion,
+      gameVersion: globalScene.game.config.gameVersion as VersionString,
       timestamp: Date.now(),
       challenges: globalScene.gameMode.challenges.map(c => new ChallengeData(c)),
       mysteryEncounterType: globalScene.currentBattle.mysteryEncounter?.encounterType ?? -1,

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -436,7 +436,7 @@ export class GameData {
         localStorage.setItem(lsItemKey, "");
       }
 
-      if (!isDev && !isBeta && compareVersions(systemData.gameVersion, version as VersionString) > 0) {
+      if (!isDev && !isBeta && compareVersions(systemData.gameVersion, version as VersionString) === 1) {
         await globalScene.ui.setMode(UiMode.ALERT_MODAL, ErrorMessages.GAME_OUT_OF_DATE);
 
         globalScene.time.delayedCall(fixedInt(1000), () => {

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -109,6 +109,12 @@ export class GameData {
   public eggPity: number[];
   public unlockPity: number[];
 
+  /**
+   * A record tracking which migrators have been applied to the save data,
+   * timestamped by the date in Unix milliseconds.
+   * @remarks
+   * Used for backend server validation.
+   */
   public appliedMigrators: AppliedMigrators = {};
 
   /**

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -436,7 +436,7 @@ export class GameData {
         localStorage.setItem(lsItemKey, "");
       }
 
-      if (!isDev && !isBeta && compareVersions(systemData.gameVersion, version) === 1) {
+      if (!isDev && !isBeta && compareVersions(systemData.gameVersion, version as VersionString) > 0) {
         await globalScene.ui.setMode(UiMode.ALERT_MODAL, ErrorMessages.GAME_OUT_OF_DATE);
 
         globalScene.time.delayedCall(fixedInt(1000), () => {

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -190,10 +190,6 @@ export function applySessionVersionMigration(data: Record<string, unknown> | nul
  * Convert incoming settings data that has a version below the
  * current version number listed in `package.json`.
  * @param data - The settings data object to migrate
- * @remarks
- * Note that no transforms act on the data if its version matches
- * the current version or if there are no migrations made between its version up
- * to the current version.
  */
 export function applySettingsVersionMigration(data: object): void {
   if (!data || typeof data !== "object") {

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -135,16 +135,12 @@ export type SettingsMigratorVersions = MapToVersionNumbers<typeof settingsMigrat
 /**
  * Convert incoming {@linkcode SystemSaveData} that has a version below the
  * current version number listed in `package.json`.
- *
- * Note that no transforms act on the {@linkcode data} if its version matches
- * the current version or if there are no migrations made between its version up
- * to the current version.
  * @param data - The {@linkcode SystemSaveData} to migrate
  */
 export function applySystemVersionMigration(data: SystemSaveData): void {
   const prevVersion = data.gameVersion;
 
-  const isCurrentVersionHigher = compareVersions(LATEST_VERSION, prevVersion) > 0;
+  const isCurrentVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === -1;
   if (isCurrentVersionHigher) {
     applyMigrators(systemMigrators, data, prevVersion);
     console.log(`System data successfully migrated to v${LATEST_VERSION}!`);
@@ -154,10 +150,6 @@ export function applySystemVersionMigration(data: SystemSaveData): void {
 /**
  * Convert incoming {@linkcode SessionSaveData} that has a version below the
  * current version number listed in `package.json`.
- *
- * Note that no transforms act on the {@linkcode data} if its version matches
- * the current version or if there are no migrations made between its version up
- * to the current version.
  * @param data - The {@linkcode SessionSaveData} to migrate
  */
 export function applySessionVersionMigration(data: Record<string, unknown> | null): void {
@@ -167,11 +159,12 @@ export function applySessionVersionMigration(data: Record<string, unknown> | nul
     || typeof data.gameVersion !== "string"
     || !isValidVersionString(data.gameVersion)
   ) {
-    console.warn("Session data is missing a valid gameVersion. Skipping migration.");
+    console.warn("Session data is invalid or missing a valid gameVersion. Skipping migration.");
     return;
   }
 
-  const isCurrentVersionHigher = compareVersions(LATEST_VERSION, data.gameVersion) > 0;
+  const prevVersion = data.gameVersion;
+  const isCurrentVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === -1;
   if (isCurrentVersionHigher) {
     // Always sanitize money as a safeguard
     data.money = Math.floor(data.money as number);
@@ -188,7 +181,7 @@ export function applySessionVersionMigration(data: Record<string, unknown> | nul
       throw new SessionMigrationError("Session data has an invalid enemyParty array. Cannot migrate.");
     }
 
-    applyMigrators(sessionMigrators, data as SessionSaveMigratorIn, data.gameVersion);
+    applyMigrators(sessionMigrators, data as SessionSaveMigratorIn, prevVersion);
     console.log(`Session data successfully migrated to v${LATEST_VERSION}!`);
   }
 }
@@ -196,11 +189,11 @@ export function applySessionVersionMigration(data: Record<string, unknown> | nul
 /**
  * Convert incoming settings data that has a version below the
  * current version number listed in `package.json`.
- *
- * Note that no transforms act on the {@linkcode data} if its version matches
+ * @param data - The settings data object to migrate
+ * @remarks
+ * Note that no transforms act on the data if its version matches
  * the current version or if there are no migrations made between its version up
  * to the current version.
- * @param data - The settings data object to migrate
  */
 export function applySettingsVersionMigration(data: object): void {
   if (!data || typeof data !== "object") {
@@ -210,7 +203,7 @@ export function applySettingsVersionMigration(data: object): void {
 
   const prevVersion: VersionString = data["gameVersion"] ?? data["meta"]["gameVersion"] ?? "1.0.0";
 
-  const isCurrentVersionHigher = compareVersions(LATEST_VERSION, prevVersion) > 0;
+  const isCurrentVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === -1;
   if (isCurrentVersionHigher) {
     applyMigrators(settingsMigrators, data, prevVersion);
     data["meta"]["gameVersion"] = LATEST_VERSION;
@@ -234,7 +227,7 @@ function applyMigrators<D extends object>(
   saveVersion: VersionString,
 ): void {
   for (const migrator of migrators) {
-    if (compareVersions(migrator.version, saveVersion) > 0) {
+    if (compareVersions(migrator.version, saveVersion) === 1) {
       continue;
     }
 

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -223,7 +223,7 @@ function applyMigrators<D extends object>(
   saveVersion: VersionString,
 ): void {
   for (const migrator of migrators) {
-    if (compareVersions(migrator.version, saveVersion) === 1) {
+    if (compareVersions(saveVersion, migrator.version) !== -1) {
       continue;
     }
 

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -1,5 +1,3 @@
-// biome-ignore-all lint/performance/noNamespaceImport: Convenience (there's no need to worry about tree-shaking/etc here)
-
 import { GameDataType } from "#enums/game-data-type";
 import { version } from "#package.json";
 import { SessionMigrationError } from "#system/migration-errors";
@@ -17,6 +15,8 @@ import { compareVersions, isValidVersionString, validateIsArrayOfObjects } from 
 
 // #region Migrator Imports
 
+// biome-ignore-start lint/performance/noNamespaceImport: Convenience (there's no need to worry about tree-shaking/etc here)
+
 import * as v1_0_3 from "#system/v1_0_3";
 import * as v1_0_4 from "#system/v1_0_4";
 import * as v1_7_0 from "#system/v1_7_0";
@@ -29,6 +29,8 @@ import * as v1_12_0_1 from "#system/v1_12_0_1";
 import * as v1_12_0_3 from "#system/v1_12_0_3";
 import * as v1_12_0_10 from "#system/v1_12_0_10";
 import * as v1_12_1_0 from "#system/v1_12_1_0";
+
+// biome-ignore-end lint/performance/noNamespaceImport: Convenience (there's no need to worry about tree-shaking/etc here)
 
 // #endregion Migrator Imports
 
@@ -113,14 +115,14 @@ const settingsMigrators = [
 
 // #region Migrator Sorting Typecheck Code
 
-// Export the types for the migrator versions to be checked inside version-types.test-d.ts.
-
 type MapToVersionNumbers<M extends readonly SaveMigrator[]> = M extends readonly [
   infer First extends SaveMigrator,
   ...infer Rest extends readonly SaveMigrator[],
 ]
   ? [First["version"], ...MapToVersionNumbers<Rest>]
   : [];
+
+// Export the types for the migrator versions to be checked inside version-types.test-d.ts.
 
 export type SystemMigratorVersions = MapToVersionNumbers<typeof systemMigrators>;
 export type SessionMigratorVersions = MapToVersionNumbers<typeof sessionMigrators>;

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -5,13 +5,32 @@ import { version } from "#package.json";
 import { SessionMigrationError } from "#system/migration-errors";
 import type { AppliedMigrators, SessionSaveData, SystemSaveData } from "#types/save-data";
 import type {
+  SaveMigrator,
   SessionSaveMigrator,
   SessionSaveMigratorIn,
   SettingsSaveMigrator,
   SystemSaveMigrator,
+  VersionString,
 } from "#types/save-migrators";
 import { getDataTypeKey } from "#utils/data";
-import { compareVersions, validateIsArrayOfObjects } from "#utils/migrator-utils";
+import { compareVersions, isValidVersionString, validateIsArrayOfObjects } from "#utils/migrator-utils";
+
+// #region Migrator Imports
+
+import * as v1_0_3 from "#system/v1_0_3";
+import * as v1_0_4 from "#system/v1_0_4";
+import * as v1_7_0 from "#system/v1_7_0";
+import * as v1_8_3 from "#system/v1_8_3";
+import * as v1_9_0 from "#system/v1_9_0";
+import * as v1_10_0 from "#system/v1_10_0";
+import * as v1_11_19 from "#system/v1_11_19";
+import * as v1_12_0_0 from "#system/v1_12_0_0";
+import * as v1_12_0_1 from "#system/v1_12_0_1";
+import * as v1_12_0_3 from "#system/v1_12_0_3";
+import * as v1_12_0_10 from "#system/v1_12_0_10";
+import * as v1_12_1_0 from "#system/v1_12_1_0";
+
+// #endregion Migrator Imports
 
 /*
 // template for save migrator creation
@@ -32,7 +51,7 @@ const systemMigratorA: SystemSaveMigrator = {
   },
 };
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [systemMigratorA] as const;
+export const systemMigrators = [systemMigratorA] as const satisfies readonly SystemSaveMigrator[];
 
 const sessionMigratorA: SessionSaveMigrator = {
   name: "sessionMigratorA",
@@ -42,7 +61,7 @@ const sessionMigratorA: SessionSaveMigrator = {
   },
 };
 
-export const sessionMigrators: readonly SessionSaveMigrator[] = [sessionMigratorA] as const;
+export const sessionMigrators = [sessionMigratorA] as const satisfies readonly SessionSaveMigrator[];
 
 const settingsMigratorA: SettingsSaveMigrator = {
   name: "settingsMigratorA",
@@ -52,36 +71,19 @@ const settingsMigratorA: SettingsSaveMigrator = {
   },
 };
 
-export const settingsMigrators: readonly SettingsSaveMigrator[] = [settingsMigratorA] as const;
+export const settingsMigrators = [settingsMigratorA] as const satisfies readonly SettingsSaveMigrator[];
 */
 
-type SaveMigrator = SystemSaveMigrator | SessionSaveMigrator | SettingsSaveMigrator;
-type SaveData = SystemSaveData | SessionSaveMigratorIn | object;
+/**
+ * The current game version.
+ * @remarks
+ * This cannot be typed more strongly than `VersionString` because it is imported from `package.json`,
+ * and TypeScript does not infer exact value types from JSON imports.
+ */
+const LATEST_VERSION = version as VersionString;
 
-/** Current game version */
-const LATEST_VERSION = version;
-
-// #region Migrators
-
-// Add migrator imports below
-
-import * as v1_0_3 from "#system/v1_0_3";
-import * as v1_0_4 from "#system/v1_0_4";
-import * as v1_7_0 from "#system/v1_7_0";
-import * as v1_8_3 from "#system/v1_8_3";
-import * as v1_9_0 from "#system/v1_9_0";
-import * as v1_10_0 from "#system/v1_10_0";
-import * as v1_11_19 from "#system/v1_11_19";
-import * as v1_12_0_0 from "#system/v1_12_0_0";
-import * as v1_12_0_1 from "#system/v1_12_0_1";
-import * as v1_12_0_3 from "#system/v1_12_0_3";
-import * as v1_12_0_10 from "#system/v1_12_0_10";
-import * as v1_12_1_0 from "#system/v1_12_1_0";
-
-// To add a new set of migrators, add them to the appropriate array of migrators
-
-/** All system save migrators */
-const systemMigrators: SystemSaveMigrator[] = [
+/** All system save migrators. */
+const systemMigrators = [
   ...v1_0_3.systemMigrators,
   ...v1_0_4.systemMigrators,
   ...v1_7_0.systemMigrators,
@@ -91,35 +93,45 @@ const systemMigrators: SystemSaveMigrator[] = [
   ...v1_12_0_3.systemMigrators,
   ...v1_12_0_10.systemMigrators,
   ...v1_12_1_0.systemMigrators,
-];
+] as const satisfies readonly SystemSaveMigrator[];
 
-/** All session save migrators */
-const sessionMigrators: SessionSaveMigrator[] = [
+/** All session save migrators. */
+const sessionMigrators = [
   ...v1_0_4.sessionMigrators,
   ...v1_7_0.sessionMigrators,
   ...v1_9_0.sessionMigrators,
   ...v1_10_0.sessionMigrators,
   ...v1_12_0_0.sessionMigrators,
-];
+] as const satisfies readonly SessionSaveMigrator[];
 
-/** All settings migrators */
-const settingsMigrators: SettingsSaveMigrator[] = [
+/** All settings migrators. */
+const settingsMigrators = [
   ...v1_0_4.settingsMigrators,
   ...v1_11_19.settingsMigrators,
   ...v1_12_1_0.settingsMigrators,
-];
+] as const satisfies readonly SettingsSaveMigrator[];
 
-// Ensure the migrators are in the correct order so that they are consistently applied from oldest to newest
-sortMigrators(systemMigrators);
-sortMigrators(sessionMigrators);
-sortMigrators(settingsMigrators);
+// #region Migrator Sorting Typecheck Code
 
-// #endregion Migrators
+// Export the types for the migrator versions to be checked inside version-types.test-d.ts.
+
+type MapToVersionNumbers<M extends readonly SaveMigrator[]> = M extends readonly [
+  infer First extends SaveMigrator,
+  ...infer Rest extends readonly SaveMigrator[],
+]
+  ? [First["version"], ...MapToVersionNumbers<Rest>]
+  : [];
+
+export type SystemMigratorVersions = MapToVersionNumbers<typeof systemMigrators>;
+export type SessionMigratorVersions = MapToVersionNumbers<typeof sessionMigrators>;
+export type SettingsMigratorVersions = MapToVersionNumbers<typeof settingsMigrators>;
+
+// #endregion Migrator Sorting Typecheck Code
 
 // #region Migration Functions
 
 /**
- * Converts incoming {@linkcode SystemSaveData} that has a version below the
+ * Convert incoming {@linkcode SystemSaveData} that has a version below the
  * current version number listed in `package.json`.
  *
  * Note that no transforms act on the {@linkcode data} if its version matches
@@ -129,8 +141,8 @@ sortMigrators(settingsMigrators);
  */
 export function applySystemVersionMigration(data: SystemSaveData): void {
   const prevVersion = data.gameVersion;
-  const isCurrentVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === -1;
 
+  const isCurrentVersionHigher = compareVersions(LATEST_VERSION, prevVersion) > 0;
   if (isCurrentVersionHigher) {
     applyMigrators(systemMigrators, data, prevVersion);
     console.log(`System data successfully migrated to v${LATEST_VERSION}!`);
@@ -138,7 +150,7 @@ export function applySystemVersionMigration(data: SystemSaveData): void {
 }
 
 /**
- * Converts incoming {@linkcode SessionSavaData} that has a version below the
+ * Convert incoming {@linkcode SessionSaveData} that has a version below the
  * current version number listed in `package.json`.
  *
  * Note that no transforms act on the {@linkcode data} if its version matches
@@ -146,14 +158,18 @@ export function applySystemVersionMigration(data: SystemSaveData): void {
  * to the current version.
  * @param data - The {@linkcode SessionSaveData} to migrate
  */
-export function applySessionVersionMigration(data: Record<string, unknown>): void {
-  if (!data || typeof data !== "object" || !("gameVersion" in data) || typeof data.gameVersion !== "string") {
+export function applySessionVersionMigration(data: Record<string, unknown> | null): void {
+  if (
+    !data
+    || typeof data !== "object"
+    || typeof data.gameVersion !== "string"
+    || !isValidVersionString(data.gameVersion)
+  ) {
     console.warn("Session data is missing a valid gameVersion. Skipping migration.");
     return;
   }
-  const prevVersion = data.gameVersion;
-  const isCurrentVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === -1;
 
+  const isCurrentVersionHigher = compareVersions(LATEST_VERSION, data.gameVersion) > 0;
   if (isCurrentVersionHigher) {
     // Always sanitize money as a safeguard
     data.money = Math.floor(data.money as number);
@@ -165,18 +181,18 @@ export function applySessionVersionMigration(data: Record<string, unknown>): voi
     // Enemy party can be null due to some mystery encounters. Coerce to empty array before continuing
     if (data.enemyParty == null) {
       console.debug("Converting null enemyParty to empty array for migration.");
-      data.enemyParty = [];
+      data.enemyParty = [] satisfies Record<string, unknown>[];
     } else if (!validateIsArrayOfObjects(data.enemyParty)) {
       throw new SessionMigrationError("Session data has an invalid enemyParty array. Cannot migrate.");
     }
 
-    applyMigrators(sessionMigrators, data, prevVersion);
+    applyMigrators(sessionMigrators, data as SessionSaveMigratorIn, data.gameVersion);
     console.log(`Session data successfully migrated to v${LATEST_VERSION}!`);
   }
 }
 
 /**
- * Converts incoming settings data that has a version below the
+ * Convert incoming settings data that has a version below the
  * current version number listed in `package.json`.
  *
  * Note that no transforms act on the {@linkcode data} if its version matches
@@ -190,9 +206,9 @@ export function applySettingsVersionMigration(data: object): void {
     return;
   }
 
-  const prevVersion: string = data["gameVersion"] ?? data["meta"]["gameVersion"] ?? "1.0.0";
-  const isCurrentVersionHigher = compareVersions(prevVersion, LATEST_VERSION) === -1;
+  const prevVersion: VersionString = data["gameVersion"] ?? data["meta"]["gameVersion"] ?? "1.0.0";
 
+  const isCurrentVersionHigher = compareVersions(LATEST_VERSION, prevVersion) > 0;
   if (isCurrentVersionHigher) {
     applyMigrators(settingsMigrators, data, prevVersion);
     data["meta"]["gameVersion"] = LATEST_VERSION;
@@ -204,29 +220,27 @@ export function applySettingsVersionMigration(data: object): void {
 // #endregion Migration Functions
 
 // #region Utility Functions
-
-/** Sorts migrators by their stated version */
-function sortMigrators(migrators: SaveMigrator[]): void {
-  migrators.sort((a, b) => compareVersions(a.version, b.version));
-}
-
 /**
- * Applies version migrators to the player's save data.
+ * Apply version migrators to the player's data.
  * @param migrators - The {@linkcode SaveMigrator}s to be applied
- * @param data - The {@linkcode SaveData} to migrate
+ * @param data - The data to migrate
  * @param saveVersion - The version of the save data
  */
-function applyMigrators(migrators: readonly SaveMigrator[], data: SaveData, saveVersion: string): void {
+function applyMigrators<D extends object>(
+  migrators: readonly SaveMigrator<D>[],
+  data: D,
+  saveVersion: VersionString,
+): void {
   for (const migrator of migrators) {
-    const isMigratorVersionHigher = compareVersions(saveVersion, migrator.version) === -1;
+    if (compareVersions(migrator.version, saveVersion) > 0) {
+      continue;
+    }
 
-    if (isMigratorVersionHigher) {
-      migrator.migrate(data as any);
+    migrator.migrate(data);
 
-      if ("appliedMigrators" in data) {
-        const migratorNameVersion = `${migrator.version}-${migrator.name}`;
-        (data.appliedMigrators as AppliedMigrators)[migratorNameVersion] = Date.now();
-      }
+    if ("appliedMigrators" in data) {
+      const migratorNameVersion: keyof AppliedMigrators = `${migrator.version}-${migrator.name}`;
+      (data.appliedMigrators as AppliedMigrators)[migratorNameVersion] = Date.now();
     }
   }
 }

--- a/src/system/version-migration/versions/v1_0_3.ts
+++ b/src/system/version-migration/versions/v1_0_3.ts
@@ -5,7 +5,7 @@ import { DexAttr } from "#enums/dex-attr";
 import type { SystemSaveData } from "#types/save-data";
 import type { SystemSaveMigrator } from "#types/save-migrators";
 
-const createStarterData: SystemSaveMigrator = {
+const createStarterData = {
   name: "createStarterData",
   version: "1.0.3",
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: it's simpler this way
@@ -80,6 +80,6 @@ const createStarterData: SystemSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [createStarterData] as const;
+export const systemMigrators = [createStarterData] as const satisfies readonly SystemSaveMigrator[];

--- a/src/system/version-migration/versions/v1_0_4.ts
+++ b/src/system/version-migration/versions/v1_0_4.ts
@@ -10,7 +10,7 @@ import { validateIsArrayOfObjects } from "#utils/migrator-utils";
  * Migrate ability starter data if empty for caught species.
  * @param data - {@linkcode SystemSaveData}
  */
-const migrateAbilityData: SystemSaveMigrator = {
+const migrateAbilityData = {
   name: "migrateAbilityData",
   version: "1.0.4",
   migrate: (data: SystemSaveData): void => {
@@ -22,13 +22,13 @@ const migrateAbilityData: SystemSaveMigrator = {
       });
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
 /**
  * Populate legendary Pokémon statistics if they are missing.
  * @param data - {@linkcode SystemSaveData}
  */
-const fixLegendaryStats: SystemSaveMigrator = {
+const fixLegendaryStats = {
   name: "fixLegendaryStats",
   version: "1.0.4",
   migrate: (data: SystemSaveData): void => {
@@ -72,13 +72,13 @@ const fixLegendaryStats: SystemSaveMigrator = {
       );
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
 /**
  * Unlock all starters' first ability and female gender option.
  * @param data - {@linkcode SystemSaveData}
  */
-const fixStarterData: SystemSaveMigrator = {
+const fixStarterData = {
   name: "fixStarterData",
   version: "1.0.4",
   migrate: (data: SystemSaveData): void => {
@@ -93,31 +93,31 @@ const fixStarterData: SystemSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [
+export const systemMigrators = [
   migrateAbilityData,
   fixLegendaryStats,
   fixStarterData,
-] as const;
+] as const satisfies readonly SystemSaveMigrator[];
 
 /**
  * Migrate from `"REROLL_TARGET"` property to `"SHOP_CURSOR_TARGET"`
  * @param data - The `settings` object
  */
-const fixRerollTarget: SettingsSaveMigrator = {
+const fixRerollTarget = {
   name: "fixRerollTarget",
   version: "1.0.4",
-  migrate: (data: object): void => {
+  migrate: data => {
     if (Object.hasOwn(data, "REROLL_TARGET") && !Object.hasOwn(data, "SHOP_CURSOR_TARGET")) {
       data["SHOP_CURSOR_TARGET"] = data["REROLL_TARGET"];
       // biome-ignore lint/performance/noDelete: intentional
       delete data["REROLL_TARGET"];
     }
   },
-};
+} as const satisfies SettingsSaveMigrator;
 
-export const settingsMigrators: readonly SettingsSaveMigrator[] = [fixRerollTarget] as const;
+export const settingsMigrators = [fixRerollTarget] as const satisfies readonly SettingsSaveMigrator[];
 
 /**
  *  Converts old lapsing modifiers (battle items, lures, and Dire Hit) and
@@ -125,7 +125,7 @@ export const settingsMigrators: readonly SettingsSaveMigrator[] = [fixRerollTarg
  *  names and/or change in reload arguments.
  *  @param data - {@linkcode SessionSaveData}
  */
-const migrateModifiers: SessionSaveMigrator = {
+const migrateModifiers = {
   name: "migrateModifiers",
   version: "1.0.4",
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: necessary?
@@ -191,9 +191,9 @@ const migrateModifiers: SessionSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-const migrateCustomPokemonData: SessionSaveMigrator = {
+const migrateCustomPokemonData = {
   name: "migrateCustomPokemonData",
   version: "1.0.4",
   migrate: data => {
@@ -218,6 +218,9 @@ const migrateCustomPokemonData: SessionSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-export const sessionMigrators: readonly SessionSaveMigrator[] = [migrateModifiers, migrateCustomPokemonData] as const;
+export const sessionMigrators = [
+  migrateModifiers,
+  migrateCustomPokemonData,
+] as const satisfies readonly SessionSaveMigrator[];

--- a/src/system/version-migration/versions/v1_10_0.ts
+++ b/src/system/version-migration/versions/v1_10_0.ts
@@ -45,7 +45,7 @@ function migrateSummonData(summonData: Record<string, unknown>): void {
  * Needed to ensure Last Resort and move-calling moves still work OK.
  * @param data - {@linkcode SystemSaveData}
  */
-const fixMoveHistory: SessionSaveMigrator = {
+const fixMoveHistory = {
   name: "fixMoveHistory",
   version: "1.10.0",
   migrate: data => {
@@ -62,6 +62,6 @@ const fixMoveHistory: SessionSaveMigrator = {
       });
     }
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-export const sessionMigrators: readonly SessionSaveMigrator[] = [fixMoveHistory] as const;
+export const sessionMigrators = [fixMoveHistory] as const satisfies readonly SessionSaveMigrator[];

--- a/src/system/version-migration/versions/v1_11_19.ts
+++ b/src/system/version-migration/versions/v1_11_19.ts
@@ -4,7 +4,7 @@ import type { SettingsSaveMigrator } from "#types/save-migrators";
  * Migrate old values of the game speed setting to new values
  * @param data - The `settings` object
  */
-const fixGameSpeed: SettingsSaveMigrator = {
+const fixGameSpeed = {
   name: "fixGameSpeed",
   version: "1.11.19",
   migrate: (data: object): void => {
@@ -23,6 +23,6 @@ const fixGameSpeed: SettingsSaveMigrator = {
       data["GAME_SPEED"] = newValue;
     }
   },
-};
+} as const satisfies SettingsSaveMigrator;
 
-export const settingsMigrators: readonly SettingsSaveMigrator[] = [fixGameSpeed] as const;
+export const settingsMigrators = [fixGameSpeed] as const satisfies readonly SettingsSaveMigrator[];

--- a/src/system/version-migration/versions/v1_12_0_0.ts
+++ b/src/system/version-migration/versions/v1_12_0_0.ts
@@ -150,7 +150,7 @@ function migrateSystemHisuiBasculin(data: SystemSaveData): void {
  * Version 1.12 split battle bond greninja into its own species.
  * The migrator will copy over some of the data.
  */
-const migrateSpeciesSplitSystem: SystemSaveMigrator = {
+const migrateSpeciesSplitSystem = {
   name: "migrateSpeciesSplitSystem",
   version: "1.12.0.0",
   migrate: (data: SystemSaveData): void => {
@@ -161,7 +161,7 @@ const migrateSpeciesSplitSystem: SystemSaveMigrator = {
     migrateSystemGreninjaBattleBondForm(data);
     migrateSystemHisuiBasculin(data);
   },
-};
+} as const satisfies SystemSaveMigrator;
 
 /**
  * Migrate a pokemon entry that may have had battle bond froakie
@@ -222,7 +222,7 @@ function migrateSessionHisuiBasculin(pokemon: Record<string, unknown>, replaceSp
  * Migrator for battle bond froakie line and hisui basculin form, both of which
  * split into their own species in 1.12.0.0
  */
-const migrateSpeciesSplitSession: SessionSaveMigrator = {
+const migrateSpeciesSplitSession = {
   name: "migrateSpeciesSplitSession",
   version: "1.12.0.0",
   migrate: data => {
@@ -252,9 +252,9 @@ const migrateSpeciesSplitSession: SessionSaveMigrator = {
       migrateSessionGreninjaBattleBondForm(pokemon, monoGenChallenge !== 6);
     }
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-const migrateRageFistHitCount: SessionSaveMigrator = {
+const migrateRageFistHitCount = {
   name: "migrateRageFistHitCount",
   version: "1.12.0.0",
   migrate: data => {
@@ -263,9 +263,9 @@ const migrateRageFistHitCount: SessionSaveMigrator = {
       p.summonData.hitCount = (p.battleData as { hitCount?: number })?.hitCount;
     }
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-const convertCustomPokemonDataTypes: SessionSaveMigrator = {
+const convertCustomPokemonDataTypes = {
   name: "convertCustomPokemonDataTypes",
   version: "1.12.0.0",
   migrate: data => {
@@ -283,7 +283,7 @@ const convertCustomPokemonDataTypes: SessionSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SessionSaveMigrator;
 
 function shiftFormChangeModifier(modifier: Record<string, unknown>): void {
   if (modifier.className === "PokemonFormChangeItemModifier") {
@@ -301,7 +301,7 @@ function shiftFormChangeModifier(modifier: Record<string, unknown>): void {
 }
 
 /** Shift the form change item values upward to account for newly added Mega Stones. */
-const shiftFormChangeItems: SessionSaveMigrator = {
+const shiftFormChangeItems = {
   name: "shiftFormChangeItems",
   version: "1.12.0.0",
   migrate: data => {
@@ -317,13 +317,13 @@ const shiftFormChangeItems: SessionSaveMigrator = {
       console.warn("Malformed enemy modifiers in save data, skipping form change item migrator for enemy party");
     }
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-export const sessionMigrators: readonly SessionSaveMigrator[] = [
+export const sessionMigrators = [
   migrateRageFistHitCount,
   convertCustomPokemonDataTypes,
   shiftFormChangeItems,
   migrateSpeciesSplitSession,
-] as const;
+] as const satisfies readonly SessionSaveMigrator[];
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [migrateSpeciesSplitSystem] as const;
+export const systemMigrators = [migrateSpeciesSplitSystem] as const satisfies readonly SystemSaveMigrator[];

--- a/src/system/version-migration/versions/v1_12_0_1.ts
+++ b/src/system/version-migration/versions/v1_12_0_1.ts
@@ -4,7 +4,7 @@ import { DexAttr } from "#enums/dex-attr";
 import { SpeciesId } from "#enums/species-id";
 import type { SystemSaveMigrator } from "#types/save-migrators";
 
-const fixDexData: SystemSaveMigrator = {
+const fixDexData = {
   name: "fixDexData",
   version: "1.12.0.1",
   migrate: (data): void => {
@@ -50,6 +50,6 @@ const fixDexData: SystemSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [fixDexData] as const;
+export const systemMigrators = [fixDexData] as const satisfies readonly SystemSaveMigrator[];

--- a/src/system/version-migration/versions/v1_12_0_10.ts
+++ b/src/system/version-migration/versions/v1_12_0_10.ts
@@ -37,13 +37,13 @@ function removeInvalidDexData(data: SystemSaveData): void {
   }
 }
 
-const removeInvalidStarterAndDexData: SystemSaveMigrator = {
+const removeInvalidStarterAndDexData = {
   name: "removeInvalidStarterAndDexData",
   version: "1.12.0.10",
   migrate: (data: SystemSaveData): void => {
     removeInvalidStarterData(data);
     removeInvalidDexData(data);
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [removeInvalidStarterAndDexData] as const;
+export const systemMigrators = [removeInvalidStarterAndDexData] as const satisfies readonly SystemSaveMigrator[];

--- a/src/system/version-migration/versions/v1_12_0_3.ts
+++ b/src/system/version-migration/versions/v1_12_0_3.ts
@@ -103,7 +103,7 @@ function pullEggs(pullCount: number, ownedStarters: SpeciesId[]): EggData[] {
   return eggs;
 }
 
-const shinyCompensationMigrator: SystemSaveMigrator = {
+const shinyCompensationMigrator = {
   name: "shinyCompensationMigrator",
   version: "1.12.0.3",
   migrate: (data): void => {
@@ -149,9 +149,9 @@ const shinyCompensationMigrator: SystemSaveMigrator = {
       seed.toString(),
     );
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-const voucherCompensationMigrator: SystemSaveMigrator = {
+const voucherCompensationMigrator = {
   name: "voucherCompensationMigrator",
   version: "1.12.0.3",
   migrate: (data): void => {
@@ -169,10 +169,10 @@ const voucherCompensationMigrator: SystemSaveMigrator = {
     data.voucherCounts[VoucherType.PREMIUM] += 2;
     data.voucherCounts[VoucherType.GOLDEN] += 1;
   },
-};
+} as const satisfies SystemSaveMigrator;
 
 // a copy of the 1.12.0.1 migrator with the `.abilityAttr` check fixed
-const fixDexData: SystemSaveMigrator = {
+const fixDexData = {
   name: "fixDexData",
   version: "1.12.0.3",
   migrate: (data): void => {
@@ -218,10 +218,10 @@ const fixDexData: SystemSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [
+export const systemMigrators = [
   fixDexData,
   shinyCompensationMigrator,
   voucherCompensationMigrator,
-] as const;
+] as const satisfies readonly SystemSaveMigrator[];

--- a/src/system/version-migration/versions/v1_12_1_0.ts
+++ b/src/system/version-migration/versions/v1_12_1_0.ts
@@ -429,18 +429,18 @@ function migrateValues(data: object): void {
 
 // #region Migrators
 
-const migrateSettings: SettingsSaveMigrator = {
+const migrateSettings = {
   name: "migrateSettings",
   version: "1.12.1.0",
   migrate: (data: object): void => {
     migrateKeys(data);
     migrateValues(data);
   },
-};
+} as const satisfies SettingsSaveMigrator;
 
-export const settingsMigrators: readonly SettingsSaveMigrator[] = [migrateSettings] as const;
+export const settingsMigrators = [migrateSettings] as const satisfies readonly SettingsSaveMigrator[];
 
-const migrateStarterPreferences: SystemSaveMigrator = {
+const migrateStarterPreferences = {
   name: "migrateStarterPreferences",
   version: "1.12.1.0",
   migrate: (_data: object): void => {
@@ -456,8 +456,8 @@ const migrateStarterPreferences: SystemSaveMigrator = {
 
     saveStarterPreferences(newStarterPreferences);
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [migrateStarterPreferences] as const;
+export const systemMigrators = [migrateStarterPreferences] as const satisfies readonly SystemSaveMigrator[];
 
 // #endregion Migrators

--- a/src/system/version-migration/versions/v1_7_0.ts
+++ b/src/system/version-migration/versions/v1_7_0.ts
@@ -10,9 +10,8 @@ import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 /**
  * If a starter is caught, but the only forms registered as caught are not starterSelectable,
  * unlock the default form.
- * @param data - {@linkcode SystemSaveData}
  */
-const migrateUnselectableForms: SystemSaveMigrator = {
+const migrateUnselectableForms = {
   name: "migrateUnselectableForms",
   version: "1.7.0",
   migrate: (data: SystemSaveData): void => {
@@ -37,15 +36,15 @@ const migrateUnselectableForms: SystemSaveMigrator = {
       });
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [migrateUnselectableForms] as const;
+export const systemMigrators = [migrateUnselectableForms] as const satisfies readonly SystemSaveMigrator[];
 
 function isArrayOfAtLeastTwo(arr: unknown): arr is unknown[] {
   return Array.isArray(arr) && arr.length >= 2;
 }
 
-const migrateTera: SessionSaveMigrator = {
+const migrateTera = {
   name: "migrateTera",
   version: "1.7.0",
   migrate: data => {
@@ -114,6 +113,6 @@ const migrateTera: SessionSaveMigrator = {
       }
     });
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-export const sessionMigrators: readonly SessionSaveMigrator[] = [migrateTera] as const;
+export const sessionMigrators = [migrateTera] as const satisfies readonly SessionSaveMigrator[];

--- a/src/system/version-migration/versions/v1_8_3.ts
+++ b/src/system/version-migration/versions/v1_8_3.ts
@@ -9,7 +9,7 @@ import type { SystemSaveMigrator } from "#types/save-migrators";
  * unlock the default form.
  * @param data - {@linkcode SystemSaveData}
  */
-const migratePichuForms: SystemSaveMigrator = {
+const migratePichuForms = {
   name: "migratePichuForms",
   version: "1.8.3",
   migrate: (data: SystemSaveData): void => {
@@ -27,6 +27,6 @@ const migratePichuForms: SystemSaveMigrator = {
       }
     }
   },
-};
+} as const satisfies SystemSaveMigrator;
 
-export const systemMigrators: readonly SystemSaveMigrator[] = [migratePichuForms] as const;
+export const systemMigrators = [migratePichuForms] as const satisfies readonly SystemSaveMigrator[];

--- a/src/system/version-migration/versions/v1_9_0.ts
+++ b/src/system/version-migration/versions/v1_9_0.ts
@@ -1,4 +1,4 @@
-import type { SessionSaveMigrator } from "#types/save-migrators";
+import type { SessionSaveMigrator, SessionSaveMigratorIn } from "#types/save-migrators";
 
 function updatePokemonMoveset(data: Record<string, unknown>): void {
   if (typeof data.customPokemonData !== "object" || data.customPokemonData === null) {
@@ -20,15 +20,14 @@ function updatePokemonMoveset(data: Record<string, unknown>): void {
 /**
  * Migrate all lingering rage fist data inside `CustomPokemonData`,
  * as well as enforcing default values across the board.
- * @param data - {@linkcode SystemSaveData}
  */
-const migratePartyData: SessionSaveMigrator = {
+const migratePartyData = {
   name: "migratePartyData",
   version: "1.9.0",
-  migrate: data => {
+  migrate: (data: SessionSaveMigratorIn): void => {
     data.party.forEach(updatePokemonMoveset);
     data.enemyParty.forEach(updatePokemonMoveset);
   },
-};
+} as const satisfies SessionSaveMigrator;
 
-export const sessionMigrators: readonly SessionSaveMigrator[] = [migratePartyData] as const;
+export const sessionMigrators = [migratePartyData] as const satisfies readonly SessionSaveMigrator[];

--- a/src/utils/migrator-utils.ts
+++ b/src/utils/migrator-utils.ts
@@ -1,4 +1,6 @@
+import type { CompareVersions, VersionString } from "#types/save-migrators";
 import type { StringLiteral } from "#types/type-helpers";
+import type { TupleOf } from "type-fest";
 
 /**
  * Determine whether the object is an array of non-null objects.
@@ -44,43 +46,22 @@ export function isPropertyAnObject<const T extends string>(
   return typeof data[property] === "object" && data[property] !== null;
 }
 
-/**
- * Converts a version string into an array of numbers for use in the comparison function.
- * @param versionString - The version to convert
- * @returns An array of numbers corresponding to the input version
- * @throws An error if the version string is not valid (of the form "#.#.#[.#]")
- * @example
- * ```ts
- * extractVersion("1.2.3"); // output: [1, 2, 3, 0]
- * extractVersion("1.2.3.4"); // output: [1, 2, 3, 4]
- * extractVersion("1..2.3"); // throws error
- * extractVersion("1.2.3.4.5"); // throws error
- * ```
- */
-function extractVersion(versionString: string): number[] {
-  // https://regex101.com/r/7r1299/1
-  const regex = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
-  if (!regex.test(versionString)) {
-    throw new Error(`Invalid version string (${versionString}) in version migrator!`);
-  }
-
-  const versionArray = versionString.split(".").map(v => Number.parseInt(v));
-  if (versionArray.length === 3) {
-    versionArray.push(0);
-  }
-  return versionArray;
-}
+// #region Version string utils
 
 /**
- * Compares two versions and returns whether one is newer than the other.
+ * Compare two version and returns whether one is newer than the other.
  * @param versionA - The first version to compare
  * @param versionB - The second version to compare
- * @returns The result of the comparison:
+ * @returns A 3-way comparison of the two versions:
  * - `1`: `versionA` is newer
  * - `-1`: `versionB` is newer
  * - `0`: The versions are equal
  */
-export function compareVersions(versionA: string, versionB: string): -1 | 0 | 1 {
+export function compareVersions<A extends VersionString, B extends VersionString>(
+  versionA: A,
+  versionB: B,
+): CompareVersions<A, B>;
+export function compareVersions(versionA: VersionString, versionB: VersionString): -1 | 0 | 1 {
   const a = extractVersion(versionA);
   const b = extractVersion(versionB);
 
@@ -95,3 +76,37 @@ export function compareVersions(versionA: string, versionB: string): -1 | 0 | 1 
 
   return 0;
 }
+
+/**
+ * Converts a version string into an array of numbers for use in the comparison function.
+ * @param versionString - The {@linkcode VersionString} to convert
+ * @returns A tuple of numbers corresponding to the input version
+ * @throws {Error}
+ * Throws if the version string is not a valid {@linkcode VersionString}.
+ * @example
+ * ```ts
+ * extractVersion("1.2.3"); // output: [1, 2, 3, 0]
+ * extractVersion("1.2.3.4"); // output: [1, 2, 3, 4]
+ * extractVersion("1..2.3"); // throws error
+ * extractVersion("1.2.3.4.5"); // throws error
+ * ```
+ */
+function extractVersion(versionString: VersionString): TupleOf<4, number> {
+  if (!isValidVersionString(versionString)) {
+    throw new Error(`Invalid version string (${versionString}) in version migrator!`);
+  }
+
+  const versionArray = versionString.split(".").map(v => Number.parseInt(v));
+  if (versionArray.length === 3) {
+    versionArray.push(0);
+  }
+  return versionArray as TupleOf<4, number>;
+}
+
+/** @returns Whether `s` is a valid {@linkcode VersionString}. */
+export function isValidVersionString(s: string): s is VersionString {
+  // https://regex101.com/r/7r1299/1
+  return /^\d+\.\d+\.\d+(?:\.\d+)?$/.test(s);
+}
+
+// #endregion Version string utils

--- a/src/utils/migrator-utils.ts
+++ b/src/utils/migrator-utils.ts
@@ -53,9 +53,9 @@ export function isPropertyAnObject<const T extends string>(
  * @param versionA - The first version to compare
  * @param versionB - The second version to compare
  * @returns A 3-way comparison of the two versions:
- * - `1`: `versionA` is newer
- * - `-1`: `versionB` is newer
- * - `0`: The versions are equal
+ * - `1`: `versionA > versionB`
+ * - `0`: `versionA === versionB`
+ * - `-1`: `versionA < versionB`
  */
 export function compareVersions<A extends VersionString, B extends VersionString>(
   versionA: A,

--- a/test/tests/types/version-types.test-d.ts
+++ b/test/tests/types/version-types.test-d.ts
@@ -1,0 +1,49 @@
+import type {
+  SessionMigratorVersions,
+  SettingsMigratorVersions,
+  SystemMigratorVersions,
+} from "#system/version-migration/version-converter";
+import type { AreVersionsSorted, CompareVersions, VersionString } from "#types/save-migrators";
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("CompareVersions", () => {
+  it("should correctly compare version strings", () => {
+    // legacy version strings
+    expectTypeOf<CompareVersions<"1.0.0", "1.0.1">>().toEqualTypeOf<-1>();
+    expectTypeOf<CompareVersions<"1.0.1", "1.0.0">>().toEqualTypeOf<1>();
+    expectTypeOf<CompareVersions<"1.0.0", "1.0.0">>().toEqualTypeOf<0>();
+    expectTypeOf<CompareVersions<"1.2.3", "1.2.4">>().toEqualTypeOf<-1>();
+    expectTypeOf<CompareVersions<"1.2.4", "1.2.3">>().toEqualTypeOf<1>();
+    expectTypeOf<CompareVersions<"1.2.3", "1.2.3">>().toEqualTypeOf<0>();
+    expectTypeOf<CompareVersions<"1.10.0", "1.9.9">>().toEqualTypeOf<1>();
+    expectTypeOf<CompareVersions<"1.9.9", "1.10.0">>().toEqualTypeOf<-1>();
+    expectTypeOf<CompareVersions<"1.10.0", "1.10.0">>().toEqualTypeOf<0>();
+    // Modern version strings
+    expectTypeOf<CompareVersions<"1.12.0.0", "1.12.0.1">>().toEqualTypeOf<-1>();
+    expectTypeOf<CompareVersions<"1.12.0.1", "1.12.0.0">>().toEqualTypeOf<1>();
+    expectTypeOf<CompareVersions<"1.12.0.0", "1.12.0.0">>().toEqualTypeOf<0>();
+    // mixed legacy and modern version strings
+    expectTypeOf<CompareVersions<"1.22.0.0", "1.11.0">>().toEqualTypeOf<1>();
+    expectTypeOf<CompareVersions<"1.12.0.0", "1.12.0">>().toEqualTypeOf<0>();
+    expectTypeOf<CompareVersions<"1.11.1", "1.12.0.1">>().toEqualTypeOf<-1>();
+  });
+});
+
+describe("Version Sorting", () => {
+  it("should correctly determine if a list of version strings is sorted in ascending order", () => {
+    expectTypeOf<AreVersionsSorted<[]>>().toEqualTypeOf<true>();
+    expectTypeOf<AreVersionsSorted<["1.0.0", VersionString]>>().toEqualTypeOf<boolean>();
+    expectTypeOf<AreVersionsSorted<["1.1.1"]>>().toEqualTypeOf<true>();
+    expectTypeOf<AreVersionsSorted<["1.1.1", "1.2.3"]>>().toEqualTypeOf<true>();
+    expectTypeOf<AreVersionsSorted<["1.0.2", "1.0.1", "1.0.0"]>>().toEqualTypeOf<false>();
+    expectTypeOf<AreVersionsSorted<["1.0.2", "1.0.2", "1.0.2"]>>().toEqualTypeOf<true>();
+    expectTypeOf<AreVersionsSorted<["1.0.2", "1.0.3", "1.0.2"]>>().toEqualTypeOf<false>();
+    expectTypeOf<AreVersionsSorted<["1.0.0", "1.0.1", "1.11.2", "1.12.0", "1.12.0.1"]>>().toEqualTypeOf<true>();
+  });
+
+  it("should have all migrator versions sorted in ascending order", () => {
+    expectTypeOf<AreVersionsSorted<SystemMigratorVersions>>().toEqualTypeOf<true>();
+    expectTypeOf<AreVersionsSorted<SessionMigratorVersions>>().toEqualTypeOf<true>();
+    expectTypeOf<AreVersionsSorted<SettingsMigratorVersions>>().toEqualTypeOf<true>();
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
1. I wanted to use template literal types to enforce (at a type level) the shape of the version numbers we are able to parse.
2. I wanted to move the sorting enforcement for migrators to the type system (since we SHOULD be able to enforce it at compile time).

## What are the changes from a developer perspective?
1. Added `VersionString` and implemented it in place of `string` for game version-related types.
2. Added type utilities to compare and check sortedness of game version strings.
3. Made all the migrator objects, arrays, and similar into `const object`s that use `satisfies` to preserve the exact version number each contains
4. Moved the namespace imports above the giant comment
5. Added a type test file to verify that the comparisons did indeed work, and to verify that all of the migrator versions were in ascending order.
6. Made `AppliedMigrators` a template literal type as well while I was at it

## Screenshots/Videos
N/A
## How to test the changes?
1. Run `pnpm exec tsgo` and see no type errors
2. Swap the order of 2 migrator imports (thus making them NOT in sorted order).
3. Notice there are type errors now

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary