### PR TITLE
dev: fix warning in `vitest.config.ts`, remove nested ternaries

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,25 +9,19 @@
 import type { UserConfig } from "vite";
 import { defineConfig } from "vitest/config";
 import { BaseSequencer, type TestSpecification } from "vitest/node";
-import { TEST_TIMEOUT } from "./test/constants";
-import { CustomDefaultReporter } from "./test/reporters/custom-default-reporter";
-import { sharedConfig } from "./vite.config";
+import { TEST_TIMEOUT } from "./test/constants.ts";
+import { CustomDefaultReporter } from "./test/reporters/custom-default-reporter.ts";
+import { sharedConfig } from "./vite.config.ts";
 
 // biome-ignore lint/style/noDefaultExport: required for vitest
 export default defineConfig(async config => {
   const viteConfig = await sharedConfig(config);
-  const opts: UserConfig = {
+  const opts = {
     ...viteConfig,
     test: {
       passWithNoTests: false,
-      reporters: process.env.MERGE_REPORTS
-        ? ["github-actions", new CustomDefaultReporter()]
-        : process.env.GITHUB_ACTIONS
-          ? ["blob", new CustomDefaultReporter()]
-          : [new CustomDefaultReporter()],
-      env: {
-        TZ: "UTC",
-      },
+      reporters: [] as (string | CustomDefaultReporter)[],
+      env: { TZ: "UTC" },
       isolate: false,
       testTimeout: TEST_TIMEOUT,
       slowTestThreshold: TEST_TIMEOUT / 2,
@@ -37,16 +31,10 @@ export default defineConfig(async config => {
       //   requireAssertions: true,
       // },
       setupFiles: ["./test/setup/font-face.setup.ts", "./test/setup/vitest.setup.ts", "./test/setup/matchers.setup.ts"],
-      sequence: {
-        sequencer: MySequencer,
-      },
+      sequence: { sequencer: MySequencer },
       includeTaskLocation: true,
       environment: "jsdom",
-      environmentOptions: {
-        jsdom: {
-          resources: "usable",
-        },
-      },
+      environmentOptions: { jsdom: { resources: "usable" } },
       typecheck: {
         tsconfig: "tsconfig.json",
         include: ["./test/tests/types/**/*.{test,spec}-d.ts"],
@@ -56,18 +44,25 @@ export default defineConfig(async config => {
       coverage: {
         provider: "v8",
         reportsDirectory: "coverage",
-        reporter: process.env.MERGE_REPORTS
-          ? ["text-summary", "json-summary"]
-          : process.env.GITHUB_ACTIONS
-            ? []
-            : ["text-summary", "html"],
+        reporter: [] as string[],
         exclude: ["{src,test}/**/*.d.ts"],
         include: ["src/**/*.ts", "test/utils/**/*.ts"],
       },
       name: "main",
       include: ["./test/**/*.{test,spec}.ts"],
     },
-  };
+  } satisfies UserConfig;
+
+  if (process.env.MERGE_REPORTS) {
+    opts.test.reporters.push("github-actions");
+    opts.test.coverage.reporter = ["text-summary", "json-summary"];
+  } else if (process.env.GITHUB_ACTIONS) {
+    opts.test.reporters.push("blob");
+  } else {
+    opts.test.coverage.reporter = ["text-summary", "html"];
+  }
+  opts.test.reporters.push(new CustomDefaultReporter());
+
   return opts;
 });
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The import extension change was missed in #7608 when updating Vite and Vitest.

## What are the changes from a developer perspective?
Updated the imports to add `.ts` as necessary.
Replaced the nested ternaries with an `if`/`else` chain.

## How to test the changes?
`pnpm test:silent [test-file-name]`
There should be no warnings.
<details><summary>Warning message on beta</summary>

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - import "./test/constants" without a file extension (vitest.config.ts:12:30). Add the file extension
  - import "./test/reporters/custom-default-reporter" without a file extension (vitest.config.ts:13:39). Add the file extension
  - import "./vite.config" without a file extension (vitest.config.ts:14:30). Add the file extension
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```

</details> 

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually