### PR TITLE
dev: add missing freeze turn param to status override

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5926,7 +5926,7 @@ export class PlayerPokemon extends Pokemon {
     super(106, 148, species, level, abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource);
 
     if (activeOverrides.STATUS_OVERRIDE) {
-      this.status = new Status(activeOverrides.STATUS_OVERRIDE, 0, 4);
+      this.status = new Status(activeOverrides.STATUS_OVERRIDE, 0, 4, 4);
     }
 
     if (activeOverrides.SHINY_OVERRIDE) {
@@ -6520,7 +6520,7 @@ export class EnemyPokemon extends Pokemon {
     }
 
     if (activeOverrides.ENEMY_STATUS_OVERRIDE) {
-      this.status = new Status(activeOverrides.ENEMY_STATUS_OVERRIDE, 0, 4);
+      this.status = new Status(activeOverrides.ENEMY_STATUS_OVERRIDE, 0, 4, 4);
     }
 
     if (activeOverrides.ENEMY_GENDER_OVERRIDE !== null) {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Noticed due to a comment in another PR.

## What are the changes from a developer perspective?
Passes 4 to the `freezeTurnsRemaining` param in the `Status()` constructor when using the status override.

## How to test the changes?
Use the status effect overrides.
```ts
const overrides = {
  STATUS_OVERRIDE: StatusEffect.FREEZE,
  ENEMY_STATUS_OVERRIDE: StatusEffect.FREEZE,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR