### PR TITLE
i18n: Update locales usages for modifier rework

### DIFF
--- a/src/@types/locales.ts
+++ b/src/@types/locales.ts
@@ -24,34 +24,21 @@ export interface AbilityTranslationEntries {
   [key: string]: AbilityTranslationEntry;
 }
 
-export interface RewardTranslationEntry {
+export interface ItemTranslationEntry {
   name?: string;
   description?: string;
   extra?: SimpleTranslationEntries;
 }
 
 export interface RewardTranslationEntries {
-  Reward: { [key: string]: RewardTranslationEntry };
-  SpeciesBoosterItem: { [key: string]: RewardTranslationEntry };
-  AttackTypeBoosterItem: SimpleTranslationEntries;
-  TempStatStageBoosterItem: SimpleTranslationEntries;
-  BaseStatBoosterItem: SimpleTranslationEntries;
+  Reward: { [key: string]: ItemTranslationEntry };
+  Item: { [key: string]: ItemTranslationEntry };
   EvolutionItem: SimpleTranslationEntries;
-  FormChangeItemId: SimpleTranslationEntries;
 }
 
 export interface PokemonInfoTranslationEntries {
   Stat: SimpleTranslationEntries;
   Type: SimpleTranslationEntries;
-}
-
-export interface BerryTranslationEntry {
-  name: string;
-  effect: string;
-}
-
-export interface BerryTranslationEntries {
-  [key: string]: BerryTranslationEntry;
 }
 
 export interface StatusEffectTranslationEntries {

--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -259,7 +259,7 @@ export class SpeciesFormEvolution {
       strings.push(i18next.t("pokemonEvolutions:atLevel", {lv: this.level}));
     }
     if (this.item) {
-      const itemDescription = i18next.t(`modifierType:EvolutionItem.${EvolutionItem[this.item].toUpperCase()}`);
+      const itemDescription = i18next.t(`item:${toCamelCase(EvolutionItem[this.item])}.name`);
       const rarity = this.item > 50 ? i18next.t("pokemonEvolutions:ultra") : i18next.t("pokemonEvolutions:great");
       strings.push(i18next.t("pokemonEvolutions:using", {item: itemDescription, tier: rarity}));
     }

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -11,11 +11,11 @@ import { NumberHolder, randSeedInt, toDmgValue } from "#utils/common";
 import i18next from "i18next";
 
 export function getBerryName(berryType: BerryType): string {
-  return i18next.t(`berry:${BerryType[berryType].toLowerCase()}.name`);
+  return i18next.t(`item:${BerryType[berryType].toLowerCase()}.name`);
 }
 
 export function getBerryEffectDescription(berryType: BerryType): string {
-  return i18next.t(`berry:${BerryType[berryType].toLowerCase()}.effect`);
+  return i18next.t(`item:${BerryType[berryType].toLowerCase()}.description`);
 }
 
 export type BerryPredicate = (pokemon: Pokemon) => boolean;

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -190,7 +190,7 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
         // Provides 1x Reviver Seed to each party member at end of battle
         encounter.setDialogueToken(
           "foodReward",
-          allHeldItems[HeldItemId.REVIVER_SEED].name ?? i18next.t("modifierType:ModifierType.REVIVER_SEED.name"),
+          allHeldItems[HeldItemId.REVIVER_SEED].name ?? i18next.t("item:reviverSeed.name"),
         );
         const givePartyPokemonReviverSeeds = () => {
           const party = globalScene.getPlayerParty();

--- a/src/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter.ts
+++ b/src/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter.ts
@@ -111,7 +111,7 @@ export const AnOfferYouCantRefuseEncounter: MysteryEncounter = MysteryEncounterB
     }
 
     const name = allTrainerItems[TrainerItemId.SHINY_CHARM].name;
-    encounter.setDialogueToken("itemName", name ?? i18next.t("modifierType:ModifierType.SHINY_CHARM.name"));
+    encounter.setDialogueToken("itemName", name ?? i18next.t("item:shinyCharm.name"));
     encounter.setDialogueToken("liepardName", getPokemonSpecies(SpeciesId.LIEPARD).getName());
 
     return true;

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -6,10 +6,10 @@
 import { allHeldItems } from "#data/data-lists";
 import { BerryType } from "#enums/berry-type";
 import { FormChangeItemId } from "#enums/form-change-item-id";
-import { HeldItemId, HeldItemNames } from "#enums/held-item-id";
+import { HeldItemId } from "#enums/held-item-id";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
-import { getStatKey, PERMANENT_STATS, Stat } from "#enums/stat";
+import { PERMANENT_STATS, Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { AccuracyBoosterHeldItemAttr } from "#items/accuracy-booster";
 import { AttackTypeBoostHeldItemAttr, attackTypeToHeldItem } from "#items/attack-type-booster";
@@ -97,8 +97,6 @@ const berryItems = getEnumValues(BerryType).reduce(
     berryId satisfies BerryItemId;
     ret[berryId] = new HeldItemBuilder(berryId, maxStackCount) //
       .attr(BerryHeldItemAttr, berry)
-      .name(`berry:${BerryType[berry].toLowerCase()}.name`)
-      .description(`berry:${BerryType[berry].toLowerCase()}.effect`)
       .iconName(`${BerryType[berry].toLowerCase()}_berry`)
       .build();
     return ret;
@@ -118,10 +116,6 @@ const typeBoostHeldItems = (
       .unstealable()
       .untransferable()
       .unsuppressable()
-      .name(`modifierType:AttackTypeBoosterItem.${HeldItemNames[id].toLowerCase()}`)
-      .description("modifierType:ModifierType.AttackTypeBoosterModifierType.description", {
-        moveType: `$t(pokemonInfo:Type.${PokemonType[pokemonType]})`,
-      })
       .build();
     return ret;
   },
@@ -139,10 +133,6 @@ const vitaminItems = PERMANENT_STATS.reduce(
       .unstealable()
       .untransferable()
       .unsuppressable()
-      .name(`modifierType:BaseStatBoosterItem.${statBoostItems[stat]}`)
-      .description("modifierType:ModifierType.BaseStatBoosterModifierType.description", {
-        stat: `$t(${getStatKey(stat)})`,
-      })
       .iconName(statBoostItems[stat])
       .build();
     return ret;
@@ -209,15 +199,12 @@ const heldItems = {
 
   [HeldItemId.LUCKY_EGG]: new HeldItemBuilder(HeldItemId.LUCKY_EGG, 99) //
     .attr(ExpBoosterHeldItemAttr, 40)
-    .description("modifierType:ModifierType.PokemonExpBoosterModifierType.description", { boostPercent: 40 })
     .build(),
   [HeldItemId.GOLDEN_EGG]: new HeldItemBuilder(HeldItemId.GOLDEN_EGG, 99) //
     .attr(ExpBoosterHeldItemAttr, 100)
-    .description("modifierType:ModifierType.PokemonExpBoosterModifierType.description", { boostPercent: 100 })
     .build(),
   [HeldItemId.SOOTHE_BELL]: new HeldItemBuilder(HeldItemId.SOOTHE_BELL, 3) //
     .attr(FriendshipBoosterHeldItemAttr)
-    .description("modifierType:ModifierType.PokemonFriendshipBoosterModifierType.description")
     .build(),
 
   [HeldItemId.LEFTOVERS]: new HeldItemBuilder(HeldItemId.LEFTOVERS, 4) //
@@ -225,8 +212,6 @@ const heldItems = {
     .build(),
   [HeldItemId.SHELL_BELL]: new HeldItemBuilder(HeldItemId.SHELL_BELL, 4) //
     .attr(HitHealHeldItemAttr)
-    .name("modifierType:ModifierType.SHELL_BELL.name")
-    .description("modifierType:ModifierType.SHELL_BELL.description")
     .iconName("shell_bell")
     .build(),
 
@@ -248,7 +233,6 @@ const heldItems = {
     .build(),
   [HeldItemId.MULTI_LENS]: new HeldItemBuilder(HeldItemId.MULTI_LENS, 2) //
     .attr(MultiHitCountHeldItemAttr)
-    .description("modifierType:ModifierType.PokemonMultiHitModifierType.description")
     .build(),
   [HeldItemId.GOLDEN_PUNCH]: new HeldItemBuilder(HeldItemId.GOLDEN_PUNCH, 5) //
     .attr(DamageMoneyRewardHeldItemAttr)
@@ -258,13 +242,9 @@ const heldItems = {
     .build(),
   [HeldItemId.GRIP_CLAW]: new HeldItemBuilder(HeldItemId.GRIP_CLAW, 5) //
     .attr(ContactItemStealChanceHeldItemAttr, 10)
-    .description("modifierType:ModifierType.ContactHeldItemTransferChanceModifierType.description", {
-      chancePercent: 10,
-    })
     .build(),
   [HeldItemId.MINI_BLACK_HOLE]: new HeldItemBuilder(HeldItemId.MINI_BLACK_HOLE, 1) //
     .attr(TurnEndItemStealHeldItemAttr)
-    .description("modifierType:ModifierType.TurnHeldItemTransferModifierType.description")
     .unstealable()
     .untransferable()
     .build(),
@@ -281,8 +261,7 @@ const heldItems = {
     .unstealable()
     .untransferable()
     .unsuppressable()
-    .name("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_GOOD.name")
-    .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_GOOD.description")
+    .description("item:shuckleJuiceGood.description")
     .iconName("berry_juice_good")
     .build(),
   [HeldItemId.SHUCKLE_JUICE_BAD]: new HeldItemBuilder(HeldItemId.SHUCKLE_JUICE_BAD, 1) //
@@ -290,8 +269,7 @@ const heldItems = {
     .unstealable()
     .untransferable()
     .unsuppressable()
-    .name("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_BAD.name")
-    .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_BAD.description")
+    .description("item:shuckleJuiceBad.description")
     .iconName("berry_juice_bad")
     .build(),
   [HeldItemId.OLD_GATEAU]: new HeldItemBuilder(HeldItemId.OLD_GATEAU, 1) //
@@ -299,12 +277,9 @@ const heldItems = {
     .unstealable()
     .untransferable()
     .unsuppressable()
-    .description("modifierType:ModifierType.PokemonBaseStatFlatModifierType.description")
     .build(),
   [HeldItemId.MACHO_BRACE]: new HeldItemBuilder(HeldItemId.MACHO_BRACE, 50) //
     .attr(MachoBraceHeldItemAttr)
-    .name("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.name")
-    .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.description")
     .unstealable()
     .untransferable()
     .unsuppressable()

--- a/src/items/all-rewards.ts
+++ b/src/items/all-rewards.ts
@@ -45,61 +45,55 @@ export const allRewards = {
 
   // Money rewards
   [RewardId.NUGGET]: new AddMoneyReward(
-    "modifierType:ModifierType.NUGGET",
+    "reward:nugget",
     "nugget",
     1,
-    "modifierType:ModifierType.MoneyRewardModifierType.extra.small",
+    "reward:moneyReward.extra.small",
     RewardId.NUGGET,
   ),
   [RewardId.BIG_NUGGET]: new AddMoneyReward(
-    "modifierType:ModifierType.BIG_NUGGET",
+    "reward:bigNugget",
     "big_nugget",
     2.5,
-    "modifierType:ModifierType.MoneyRewardModifierType.extra.moderate",
+    "reward:moneyReward.extra.moderate",
     RewardId.BIG_NUGGET,
   ),
   [RewardId.RELIC_GOLD]: new AddMoneyReward(
-    "modifierType:ModifierType.RELIC_GOLD",
+    "reward:relicGold",
     "relic_gold",
     10,
-    "modifierType:ModifierType.MoneyRewardModifierType.extra.large",
+    "reward:moneyReward.extra.large",
     RewardId.RELIC_GOLD,
   ),
 
   // Party-wide consumables
-  [RewardId.RARER_CANDY]: new AllPokemonLevelIncrementReward("modifierType:ModifierType.RARER_CANDY", "rarer_candy"),
-  [RewardId.SACRED_ASH]: new AllPokemonFullReviveReward("modifierType:ModifierType.SACRED_ASH", "sacred_ash"),
+  [RewardId.RARER_CANDY]: new AllPokemonLevelIncrementReward("reward:rarerCandy", "rarer_candy"),
+  [RewardId.SACRED_ASH]: new AllPokemonFullReviveReward("reward:sacredAsh", "sacred_ash"),
 
   // Pokemon consumables
-  [RewardId.RARE_CANDY]: new PokemonLevelIncrementReward("modifierType:ModifierType.RARE_CANDY", "rare_candy"),
+  [RewardId.RARE_CANDY]: new PokemonLevelIncrementReward("reward:rareCandy", "rare_candy"),
 
   [RewardId.EVOLUTION_ITEM]: new EvolutionItemRewardGenerator(false),
   [RewardId.RARE_EVOLUTION_ITEM]: new EvolutionItemRewardGenerator(true),
 
-  [RewardId.POTION]: new PokemonHpRestoreReward("modifierType:ModifierType.POTION", "potion", RewardId.POTION, 20, 10),
+  [RewardId.POTION]: new PokemonHpRestoreReward("reward:potion", "potion", RewardId.POTION, 20, 10),
   [RewardId.SUPER_POTION]: new PokemonHpRestoreReward(
-    "modifierType:ModifierType.SUPER_POTION",
+    "reward:superPotion",
     "super_potion",
     RewardId.SUPER_POTION,
     50,
     25,
   ),
   [RewardId.HYPER_POTION]: new PokemonHpRestoreReward(
-    "modifierType:ModifierType.HYPER_POTION",
+    "reward:hyperPotion",
     "hyper_potion",
     RewardId.HYPER_POTION,
     200,
     50,
   ),
-  [RewardId.MAX_POTION]: new PokemonHpRestoreReward(
-    "modifierType:ModifierType.MAX_POTION",
-    "max_potion",
-    RewardId.MAX_POTION,
-    0,
-    100,
-  ),
+  [RewardId.MAX_POTION]: new PokemonHpRestoreReward("reward:maxPotion", "max_potion", RewardId.MAX_POTION, 0, 100),
   [RewardId.FULL_RESTORE]: new PokemonHpRestoreReward(
-    "modifierType:ModifierType.FULL_RESTORE",
+    "reward:fullRestore",
     "full_restore",
     RewardId.FULL_RESTORE,
     0,
@@ -107,39 +101,19 @@ export const allRewards = {
     true,
   ),
 
-  [RewardId.REVIVE]: new PokemonReviveReward("modifierType:ModifierType.REVIVE", "revive", RewardId.REVIVE, 50),
-  [RewardId.MAX_REVIVE]: new PokemonReviveReward(
-    "modifierType:ModifierType.MAX_REVIVE",
-    "max_revive",
-    RewardId.MAX_REVIVE,
-    100,
-  ),
+  [RewardId.REVIVE]: new PokemonReviveReward("reward:revive", "revive", RewardId.REVIVE, 50),
+  [RewardId.MAX_REVIVE]: new PokemonReviveReward("reward:maxRevive", "max_revive", RewardId.MAX_REVIVE, 100),
 
-  [RewardId.FULL_HEAL]: new PokemonStatusHealReward("modifierType:ModifierType.FULL_HEAL", "full_heal"),
+  [RewardId.FULL_HEAL]: new PokemonStatusHealReward("reward:fullHeal", "full_heal"),
 
-  [RewardId.ETHER]: new PokemonPpRestoreReward("modifierType:ModifierType.ETHER", "ether", RewardId.ETHER, 10),
-  [RewardId.MAX_ETHER]: new PokemonPpRestoreReward(
-    "modifierType:ModifierType.MAX_ETHER",
-    "max_ether",
-    RewardId.MAX_ETHER,
-    -1,
-  ),
+  [RewardId.ETHER]: new PokemonPpRestoreReward("reward:ether", "ether", RewardId.ETHER, 10),
+  [RewardId.MAX_ETHER]: new PokemonPpRestoreReward("reward:maxEther", "max_ether", RewardId.MAX_ETHER, -1),
 
-  [RewardId.ELIXIR]: new PokemonAllMovePpRestoreReward(
-    "modifierType:ModifierType.ELIXIR",
-    "elixir",
-    RewardId.ELIXIR,
-    10,
-  ),
-  [RewardId.MAX_ELIXIR]: new PokemonAllMovePpRestoreReward(
-    "modifierType:ModifierType.MAX_ELIXIR",
-    "max_elixir",
-    RewardId.MAX_ELIXIR,
-    -1,
-  ),
+  [RewardId.ELIXIR]: new PokemonAllMovePpRestoreReward("reward:elixir", "elixir", RewardId.ELIXIR, 10),
+  [RewardId.MAX_ELIXIR]: new PokemonAllMovePpRestoreReward("reward:maxElixir", "max_elixir", RewardId.MAX_ELIXIR, -1),
 
-  [RewardId.PP_UP]: new PokemonPpUpReward("modifierType:ModifierType.PP_UP", "pp_up", RewardId.PP_UP, 1),
-  [RewardId.PP_MAX]: new PokemonPpUpReward("modifierType:ModifierType.PP_MAX", "pp_max", RewardId.PP_MAX, 3),
+  [RewardId.PP_UP]: new PokemonPpUpReward("reward:ppUp", "pp_up", RewardId.PP_UP, 1),
+  [RewardId.PP_MAX]: new PokemonPpUpReward("reward:ppMax", "pp_max", RewardId.PP_MAX, 3),
 
   [RewardId.MINT]: new MintRewardGenerator(),
 
@@ -149,9 +123,9 @@ export const allRewards = {
   [RewardId.TM_GREAT]: new TmRewardGenerator(RarityTier.GREAT),
   [RewardId.TM_ULTRA]: new TmRewardGenerator(RarityTier.ULTRA),
 
-  [RewardId.MEMORY_MUSHROOM]: new RememberMoveReward("modifierType:ModifierType.MEMORY_MUSHROOM", "big_mushroom"),
+  [RewardId.MEMORY_MUSHROOM]: new RememberMoveReward("reward:memoryMushroom", "big_mushroom"),
 
-  [RewardId.DNA_SPLICERS]: new FusePokemonReward("modifierType:ModifierType.DNA_SPLICERS", "dna_splicers"),
+  [RewardId.DNA_SPLICERS]: new FusePokemonReward("reward:dnaSplicers", "dna_splicers"),
 
   // Form change items
   [RewardId.FORM_CHANGE_ITEM]: new FormChangeItemRewardGenerator(false),

--- a/src/items/all-trainer-items.ts
+++ b/src/items/all-trainer-items.ts
@@ -1,5 +1,4 @@
 import { allTrainerItems } from "#data/data-lists";
-import { getStatusEffectDescriptor } from "#data/status-effect";
 import type { Stat, TempBattleStat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import type { TrainerItemEffect } from "#enums/trainer-item-effect";
@@ -40,7 +39,7 @@ import type { TrainerItemManager } from "./trainer-item-manager";
 
 const markerItems = {
   [TrainerItemId.MAP]: new MarkerTrainerItem(TrainerItemId.MAP, 1),
-  [TrainerItemId.IV_SCANNER]: new MarkerTrainerItem(TrainerItemId.IV_SCANNER, 1),
+  [TrainerItemId.IV_SCANNER]: new MarkerTrainerItem(TrainerItemId.IV_SCANNER, 1, "scanner"), // could also fix these filenames in assets
   [TrainerItemId.LOCK_CAPSULE]: new MarkerTrainerItem(TrainerItemId.LOCK_CAPSULE, 1),
   [TrainerItemId.MEGA_BRACELET]: new MarkerTrainerItem(TrainerItemId.MEGA_BRACELET, 1),
   [TrainerItemId.DYNAMAX_BAND]: new MarkerTrainerItem(TrainerItemId.DYNAMAX_BAND, 1),
@@ -50,7 +49,7 @@ const markerItems = {
   [TrainerItemId.EXP_SHARE]: new MarkerTrainerItem(TrainerItemId.EXP_SHARE, 5),
   [TrainerItemId.EXP_BALANCE]: new MarkerTrainerItem(TrainerItemId.EXP_BALANCE, 4),
 
-  [TrainerItemId.GOLDEN_BUG_NET]: new MarkerTrainerItem(TrainerItemId.GOLDEN_BUG_NET, 1),
+  [TrainerItemId.GOLDEN_BUG_NET]: new MarkerTrainerItem(TrainerItemId.GOLDEN_BUG_NET, 1, "golden_net"),
 } as const satisfies Partial<Readonly<Record<TrainerItemId, MarkerTrainerItem>>>;
 
 // #endregion Marker items
@@ -123,6 +122,7 @@ const trainerItems = {
     .build(),
   [TrainerItemId.GOLDEN_POKEBALL]: new TrainerItemBuilder(TrainerItemId.GOLDEN_POKEBALL, 3) //
     .attr(ExtraRewardTrainerItemAttr)
+    .iconName("pb_gold")
     .build(),
 
   [TrainerItemId.ABILITY_CHARM]: new TrainerItemBuilder(TrainerItemId.ABILITY_CHARM, 4) //
@@ -142,9 +142,6 @@ const trainerItems = {
   [TrainerItemId.LURE]: new TrainerItemBuilder(TrainerItemId.LURE, 10) //
     .attr(DoubleBattleChanceBoosterTrainerItemAttr)
     .lapsing()
-    .description("modifierType:ModifierType.DoubleBattleChanceBoosterModifierType.description", {
-      battleCount: 10,
-    })
     .build(),
   [TrainerItemId.SUPER_LURE]: new TrainerItemBuilder(TrainerItemId.SUPER_LURE, 15) //
     .attr(DoubleBattleChanceBoosterTrainerItemAttr)
@@ -169,30 +166,15 @@ const trainerItems = {
     .build(),
   [TrainerItemId.ENEMY_ATTACK_POISON_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_POISON_CHANCE, 10) //
     .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.POISON, 0.05)
-    .description("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
-      chancePercent: 5,
-      // TODO: This needs to use key nesting
-      statusEffect: getStatusEffectDescriptor(StatusEffect.POISON),
-    })
     .iconName("wl_antidote")
     .build(),
   [TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE, 10) //
     .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.PARALYSIS, 0.025)
     .iconName("wl_paralyze_heal")
-    .description("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
-      chancePercent: 2.5,
-      // TODO: This needs to use key nesting
-      statusEffect: getStatusEffectDescriptor(StatusEffect.PARALYSIS),
-    })
     .build(),
   [TrainerItemId.ENEMY_ATTACK_BURN_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_BURN_CHANCE, 10) //
     .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.BURN, 0.05)
     .iconName("wl_burn_heal")
-    .description("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
-      chancePercent: 5,
-      // TODO: This needs to use key nesting
-      statusEffect: getStatusEffectDescriptor(StatusEffect.BURN),
-    })
     .build(),
   [TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE]: new TrainerItemBuilder(
     TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE,

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -5,6 +5,7 @@ import type { Pokemon } from "#field/pokemon";
 import type { ConsumableHeldItemAttr, HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
 import type { HeldItemBuilder } from "#items/held-item-builder";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
+import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 import type { NonEmptyTuple } from "type-fest";
 
@@ -36,11 +37,11 @@ export abstract class HeldItemBase {
   // TODO: Remove these defaults for non-cosmetic held items (and maybe cosmetic ones as well)
   // in favor of explicitly specifying them for each item
   public get name(): string {
-    return i18next.t(`modifierType:ModifierType.${HeldItemNames[this.type]}.name`);
+    return i18next.t(`item:${toCamelCase(HeldItemNames[this.type])}.name`);
   }
 
   public get description(): string {
-    return i18next.t(`modifierType:ModifierType.${HeldItemNames[this.type]}.description`);
+    return i18next.t(`item:${toCamelCase(HeldItemNames[this.type])}.description`);
   }
 
   public get iconName(): string {

--- a/src/items/held-items/bypass-speed-chance.ts
+++ b/src/items/held-items/bypass-speed-chance.ts
@@ -27,7 +27,7 @@ export class BypassSpeedChanceHeldItemAttr extends HeldItemAttr<typeof HeldItemE
     if (isCommandFight) {
       // TODO: Remove the `itemName` parameter
       globalScene.phaseManager.queueMessage(
-        i18next.t("modifier:bypassSpeedChanceApply", {
+        i18next.t("itemApply:bypassSpeedChanceApply", {
           pokemonName: getPokemonNameWithAffix(pokemon),
           itemName: this.item.name,
         }),

--- a/src/items/held-items/evo-tracker.ts
+++ b/src/items/held-items/evo-tracker.ts
@@ -4,7 +4,6 @@ import type { SpeciesId } from "#enums/species-id";
 import { TrainerItemId } from "#enums/trainer-item-id";
 import type { Pokemon } from "#field/pokemon";
 import { CosmeticHeldItem } from "#items/held-item";
-import i18next from "i18next";
 
 /**
  * Class for cosmetic held items used to track evolution progress for certain species.
@@ -22,14 +21,6 @@ abstract class EvoTrackerHeldItem extends CosmeticHeldItem {
 }
 
 export class GimmighoulEvoTrackerHeldItem extends EvoTrackerHeldItem {
-  get name(): string {
-    return i18next.t("modifierType:ModifierType.EVOLUTION_TRACKER_GIMMIGHOUL.name");
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.EVOLUTION_TRACKER_GIMMIGHOUL.description");
-  }
-
   get iconName(): string {
     return "relic_gold";
   }

--- a/src/items/held-items/form-change-item.ts
+++ b/src/items/held-items/form-change-item.ts
@@ -4,12 +4,8 @@ import i18next from "i18next";
 
 // TODO: All form change items have max stack counts of 1 - we should edit the constructor to not store it
 export class FormChangeHeldItem extends CosmeticHeldItem {
-  get name(): string {
-    return i18next.t(`modifierType:FormChangeItemId.${HeldItemNames[this.type]}`);
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.FormChangeItemModifierType.description");
+  public override get description(): string {
+    return i18next.t("item:formChange.description");
   }
 
   get iconName(): string {

--- a/src/items/held-items/hit-heal.ts
+++ b/src/items/held-items/hit-heal.ts
@@ -27,7 +27,7 @@ export class HitHealHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.HIT_
       new PokemonHealPhase(
         pokemon.getBattlerIndex(),
         toDmgValue(pokemon.turnData.totalDamageDealt / 8) * stackCount,
-        i18next.t("modifier:hitHealApply", {
+        i18next.t("itemApply:hitHealApply", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
           typeName: this.item.name,
         }),

--- a/src/items/held-items/instant-revive.ts
+++ b/src/items/held-items/instant-revive.ts
@@ -23,7 +23,7 @@ export class InstantReviveHeldItemAttr extends ConsumableHeldItemAttr<typeof Hel
       new PokemonHealPhase(
         pokemon.getBattlerIndex(),
         toDmgValue(pokemon.getMaxHp() / 2),
-        i18next.t("modifier:pokemonInstantReviveApply", {
+        i18next.t("itemApply:pokemonInstantReviveApply", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
           typeName: this.item.name,
         }),

--- a/src/items/held-items/item-steal.ts
+++ b/src/items/held-items/item-steal.ts
@@ -88,7 +88,7 @@ export class TurnEndItemStealHeldItemAttr extends ItemTransferHeldItemAttr<typeo
   }
 
   protected override getTransferMessage({ target, pokemon }: ItemStealParams, itemId: HeldItemId): string {
-    return i18next.t("modifier:turnHeldItemTransferApply", {
+    return i18next.t("itemApply:turnHeldItemTransferApply", {
       pokemonNameWithAffix: getPokemonNameWithAffix(target),
       itemName: allHeldItems[itemId].name,
       pokemonName: pokemon.getNameToRender(),
@@ -132,7 +132,7 @@ export class ContactItemStealChanceHeldItemAttr extends ItemTransferHeldItemAttr
   }
 
   protected override getTransferMessage({ pokemon, target }: ItemStealParams, itemId: HeldItemId): string {
-    return i18next.t("modifier:contactHeldItemTransferApply", {
+    return i18next.t("itemApply:contactHeldItemTransferApply", {
       pokemonNameWithAffix: getPokemonNameWithAffix(target),
       itemName: allHeldItems[itemId].name,
       pokemonName: pokemon.getNameToRender(),

--- a/src/items/held-items/reset-negative-stat-stage.ts
+++ b/src/items/held-items/reset-negative-stat-stage.ts
@@ -23,7 +23,7 @@ export class ResetNegativeStatStageHeldItemAttr extends ConsumableHeldItemAttr<
     pokemon.summonData.statStages = pokemon.summonData.statStages.map(stage => Math.max(stage, 0));
 
     globalScene.phaseManager.queueMessage(
-      i18next.t("modifier:resetNegativeStatStageApply", {
+      i18next.t("itemApply:resetNegativeStatStageApply", {
         pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
         typeName: this.item.name,
       }),

--- a/src/items/held-items/survive-chance.ts
+++ b/src/items/held-items/survive-chance.ts
@@ -22,7 +22,7 @@ export class SurviveChanceHeldItemAttr extends HeldItemAttr<typeof HeldItemEffec
     surviveDamage.value = true;
 
     globalScene.phaseManager.queueMessage(
-      i18next.t("modifier:surviveDamageApply", {
+      i18next.t("itemApply:surviveDamageApply", {
         pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
         typeName: this.item.name,
       }),

--- a/src/items/held-items/turn-end-heal.ts
+++ b/src/items/held-items/turn-end-heal.ts
@@ -25,7 +25,7 @@ export class TurnEndHealHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.
       new PokemonHealPhase(
         pokemon.getBattlerIndex(),
         toDmgValue(pokemon.getMaxHp() / 16) * stackCount,
-        i18next.t("modifier:turnHealApply", {
+        i18next.t("itemApply:turnHealApply", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
           // TODO: consider removing the parameter
           typeName: this.item.name,

--- a/src/items/rewards/evolution-item.ts
+++ b/src/items/rewards/evolution-item.ts
@@ -7,6 +7,7 @@ import type { PlayerPokemon } from "#field/pokemon";
 import { PokemonReward, type PokemonRewardParams, RewardGenerator } from "#items/reward";
 import { PartyUiHandler } from "#ui/party-ui-handler";
 import { randSeedItem } from "#utils/common";
+import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
 export class EvolutionItemReward extends PokemonReward {
@@ -42,11 +43,11 @@ export class EvolutionItemReward extends PokemonReward {
   }
 
   get name(): string {
-    return i18next.t(`modifierType:EvolutionItem.${EvolutionItem[this.evolutionItem]}`);
+    return i18next.t(`item:${toCamelCase(EvolutionItem[this.evolutionItem])}.name`);
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.EvolutionItemModifierType.description");
+    return i18next.t("reward:evolutionItem.description");
   }
 
   /**

--- a/src/items/rewards/fuse.ts
+++ b/src/items/rewards/fuse.ts
@@ -16,7 +16,7 @@ export class FusePokemonReward extends PokemonReward {
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.FusePokemonModifierType.description");
+    return i18next.t("reward:fusePokemon.description");
   }
 
   /**

--- a/src/items/rewards/held-item-reward.ts
+++ b/src/items/rewards/held-item-reward.ts
@@ -23,12 +23,12 @@ export class HeldItemReward extends PokemonReward {
         const hasItem = pokemon.heldItemManager.hasItem(this.itemId);
         const maxStackCount = allHeldItems[this.itemId].getMaxStackCount();
         if (!maxStackCount) {
-          return i18next.t("modifierType:ModifierType.PokemonHeldItemModifierType.extra.inoperable", {
+          return i18next.t("reward:pokemonHeldItem.extra.inoperable", {
             pokemonName: getPokemonNameWithAffix(pokemon),
           });
         }
         if (hasItem && pokemon.heldItemManager.getStack(this.itemId) === maxStackCount) {
-          return i18next.t("modifierType:ModifierType.PokemonHeldItemModifierType.extra.tooMany", {
+          return i18next.t("reward:pokemonHeldItem.extra.tooMany", {
             pokemonName: getPokemonNameWithAffix(pokemon),
           });
         }

--- a/src/items/rewards/level-increment.ts
+++ b/src/items/rewards/level-increment.ts
@@ -42,7 +42,7 @@ export class PokemonLevelIncrementReward extends PokemonReward {
     let levels = 1;
     const candyJarStack = globalScene.trainerItems.getStack(TrainerItemId.CANDY_JAR);
     levels += candyJarStack;
-    return i18next.t("modifierType:ModifierType.PokemonLevelIncrementModifierType.description", { levels });
+    return i18next.t("reward:pokemonLevelIncrement.description", { levels });
   }
 
   /**
@@ -63,7 +63,7 @@ export class AllPokemonLevelIncrementReward extends Reward {
     let levels = 1;
     const candyJarStack = globalScene.trainerItems.getStack(TrainerItemId.CANDY_JAR);
     levels += candyJarStack;
-    return i18next.t("modifierType:ModifierType.AllPokemonLevelIncrementModifierType.description", { levels });
+    return i18next.t("reward:allPokemonLevelIncrement.description", { levels });
   }
 
   apply(): boolean {

--- a/src/items/rewards/money.ts
+++ b/src/items/rewards/money.ts
@@ -30,7 +30,7 @@ export class AddMoneyReward extends Reward {
     globalScene.applyPlayerItems(TrainerItemEffect.MONEY_MULTIPLIER, { numberHolder: moneyAmount });
     const formattedMoney = formatMoney(globalScene.moneyFormat, moneyAmount.value);
 
-    return i18next.t("modifierType:ModifierType.MoneyRewardModifierType.description", {
+    return i18next.t("reward:moneyReward.description", {
       moneyMultiplier: i18next.t(this.moneyMultiplierDescriptorKey as any),
       moneyAmount: formattedMoney,
     });

--- a/src/items/rewards/nature-change.ts
+++ b/src/items/rewards/nature-change.ts
@@ -35,13 +35,13 @@ export class PokemonNatureChangeReward extends PokemonReward {
   }
 
   get name(): string {
-    return i18next.t("modifierType:ModifierType.PokemonNatureChangeModifierType.name", {
+    return i18next.t("reward:pokemonNatureChange.name", {
       natureName: getNatureName(this.nature),
     });
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonNatureChangeModifierType.description", {
+    return i18next.t("reward:pokemonNatureChange.description", {
       natureName: getNatureName(this.nature, true, true, true),
     });
   }

--- a/src/items/rewards/pokeball.ts
+++ b/src/items/rewards/pokeball.ts
@@ -17,14 +17,14 @@ export class AddPokeballReward extends Reward {
   }
 
   get name(): string {
-    return i18next.t("modifierType:ModifierType.AddPokeballModifierType.name", {
+    return i18next.t("reward:addPokeball.name", {
       modifierCount: this.count,
       pokeballName: getPokeballName(this.pokeballType),
     });
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.AddPokeballModifierType.description", {
+    return i18next.t("reward:addPokeball.description", {
       modifierCount: this.count,
       pokeballName: getPokeballName(this.pokeballType),
       catchRate:

--- a/src/items/rewards/pp-restore.ts
+++ b/src/items/rewards/pp-restore.ts
@@ -35,10 +35,10 @@ export class PokemonPpRestoreReward extends PokemonMoveReward {
 
   get description(): string {
     return this.restorePoints > -1
-      ? i18next.t("modifierType:ModifierType.PokemonPpRestoreModifierType.description", {
+      ? i18next.t("reward:pokemonPpRestore.description", {
           restorePoints: this.restorePoints,
         })
-      : i18next.t("modifierType:ModifierType.PokemonPpRestoreModifierType.extra.fully");
+      : i18next.t("reward:pokemonPpRestore.extra.fully");
   }
 
   /**
@@ -79,10 +79,10 @@ export class PokemonAllMovePpRestoreReward extends PokemonReward {
 
   get description(): string {
     return this.restorePoints > -1
-      ? i18next.t("modifierType:ModifierType.PokemonAllMovePpRestoreModifierType.description", {
+      ? i18next.t("reward:pokemonAllMovePpRestore.description", {
           restorePoints: this.restorePoints,
         })
-      : i18next.t("modifierType:ModifierType.PokemonAllMovePpRestoreModifierType.extra.fully");
+      : i18next.t("reward:pokemonAllMovePpRestore.extra.fully");
   }
 
   /**

--- a/src/items/rewards/pp-up.ts
+++ b/src/items/rewards/pp-up.ts
@@ -29,7 +29,7 @@ export class PokemonPpUpReward extends PokemonMoveReward {
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonPpUpModifierType.description", { upPoints: this.upPoints });
+    return i18next.t("reward:pokemonPpUp.description", { upPoints: this.upPoints });
   }
 
   /**

--- a/src/items/rewards/restore.ts
+++ b/src/items/rewards/restore.ts
@@ -91,13 +91,13 @@ export class PokemonHpRestoreReward extends PokemonReward {
 
   get description(): string {
     return this.restorePoints
-      ? i18next.t("modifierType:ModifierType.PokemonHpRestoreModifierType.description", {
+      ? i18next.t("reward:pokemonHpRestore.description", {
           restorePoints: this.restorePoints,
           restorePercent: this.restorePercent,
         })
       : this.healStatus
-        ? i18next.t("modifierType:ModifierType.PokemonHpRestoreModifierType.extra.fullyWithStatus")
-        : i18next.t("modifierType:ModifierType.PokemonHpRestoreModifierType.extra.fully");
+        ? i18next.t("reward:pokemonHpRestore.extra.fullyWithStatus")
+        : i18next.t("reward:pokemonHpRestore.extra.fully");
   }
 
   apply({ pokemon }: PokemonRewardParams): boolean {
@@ -135,7 +135,7 @@ export class PokemonReviveReward extends PokemonHpRestoreReward {
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonReviveModifierType.description", {
+    return i18next.t("reward:pokemonRevive.description", {
       restorePercent: this.restorePercent,
     });
   }
@@ -147,7 +147,7 @@ export class PokemonReviveReward extends PokemonHpRestoreReward {
 
 export class AllPokemonFullReviveReward extends Reward {
   constructor(localeKey: string, iconImage: string) {
-    super(localeKey, iconImage, "modifierType:ModifierType.AllPokemonFullReviveModifierType");
+    super(localeKey, iconImage, "reward:allPokemonFullRevive");
     this.id = RewardId.SACRED_ASH;
   }
 

--- a/src/items/rewards/status-heal.ts
+++ b/src/items/rewards/status-heal.ts
@@ -17,7 +17,7 @@ export class PokemonStatusHealReward extends PokemonReward {
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonStatusHealModifierType.description");
+    return i18next.t("reward:pokemonStatusHeal.description");
   }
 
   apply({ pokemon }: PokemonRewardParams): boolean {

--- a/src/items/rewards/tera-type.ts
+++ b/src/items/rewards/tera-type.ts
@@ -34,13 +34,13 @@ export class ChangeTeraTypeReward extends PokemonReward {
   }
 
   get name(): string {
-    return i18next.t("modifierType:ModifierType.ChangeTeraTypeModifierType.name", {
+    return i18next.t("reward:changeTeraType.name", {
       teraType: i18next.t(`pokemonInfo:type.${toCamelCase(PokemonType[this.teraType])}`),
     });
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.ChangeTeraTypeModifierType.description", {
+    return i18next.t("reward:changeTeraType.description", {
       teraType: i18next.t(`pokemonInfo:type.${toCamelCase(PokemonType[this.teraType])}`),
     });
   }

--- a/src/items/rewards/tm.ts
+++ b/src/items/rewards/tm.ts
@@ -31,19 +31,16 @@ export class TmReward extends PokemonReward {
   }
 
   get name(): string {
-    return i18next.t("modifierType:ModifierType.TmModifierType.name", {
+    return i18next.t("reward:tm.name", {
       moveId: padInt(Object.keys(tmPoolTiers).indexOf(this.moveId.toString()) + 1, 3),
       moveName: allMoves[this.moveId].name,
     });
   }
 
   get description(): string {
-    return i18next.t(
-      globalScene.enableMoveInfo
-        ? "modifierType:ModifierType.TmModifierTypeWithInfo.description"
-        : "modifierType:ModifierType.TmModifierType.description",
-      { moveName: allMoves[this.moveId].name },
-    );
+    return i18next.t(globalScene.enableMoveInfo ? "reward:tmWithInfo.description" : "reward:tm.description", {
+      moveName: allMoves[this.moveId].name,
+    });
   }
 
   /**

--- a/src/items/rewards/voucher.ts
+++ b/src/items/rewards/voucher.ts
@@ -16,14 +16,14 @@ export class AddVoucherReward extends Reward {
   }
 
   get name(): string {
-    return i18next.t("modifierType:ModifierType.AddVoucherConsumableType.name", {
+    return i18next.t("reward:addVoucher.name", {
       modifierCount: this.count,
       voucherTypeName: getVoucherTypeName(this.voucherType),
     });
   }
 
   get description(): string {
-    return i18next.t("modifierType:ModifierType.AddVoucherConsumableType.description", {
+    return i18next.t("reward:addVoucher.description", {
       modifierCount: this.count,
       voucherTypeName: getVoucherTypeName(this.voucherType),
     });

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -221,8 +221,6 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
 }
 
 export class MarkerTrainerItem extends TrainerItemBase {
-  private declare readonly _: never;
-
   private readonly customIconName?: string | undefined;
 
   constructor(type: TrainerItemId, maxStackCount: number, iconName?: string | undefined) {

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -8,6 +8,7 @@ import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
 import { addTextObject } from "#ui/text";
 import { hslToHex } from "#utils/color-utils";
+import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 import type { NonEmptyTuple } from "type-fest";
 
@@ -40,11 +41,11 @@ export abstract class TrainerItemBase {
   }
 
   public get name(): string {
-    return i18next.t(`modifierType:ModifierType.${TrainerItemNames[this.type]}.name`);
+    return i18next.t(`item:${toCamelCase(TrainerItemNames[this.type])}.name`);
   }
 
   public get description(): string {
-    return i18next.t(`modifierType:ModifierType.${TrainerItemNames[this.type]}.description`);
+    return i18next.t(`item:${toCamelCase(TrainerItemNames[this.type])}.description`);
   }
 
   public get iconName(): string {
@@ -221,4 +222,16 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
 
 export class MarkerTrainerItem extends TrainerItemBase {
   private declare readonly _: never;
+
+  private readonly customIconName?: string | undefined;
+
+  constructor(type: TrainerItemId, maxStackCount: number, iconName?: string | undefined) {
+    super(type, maxStackCount);
+
+    this.customIconName = iconName;
+  }
+
+  public override get iconName(): string {
+    return this.customIconName ?? super.iconName;
+  }
 }

--- a/src/items/trainer-items/enemy-tokens.ts
+++ b/src/items/trainer-items/enemy-tokens.ts
@@ -90,7 +90,7 @@ export class EnemyTurnHealTrainerItemAttr extends TrainerItemAttr<typeof Trainer
       enemyPokemon.getBattlerIndex(),
       // TODO: Do we need to round this?
       Math.max(Math.floor(enemyPokemon.getMaxHp() * this.healPercent * stack), 1),
-      i18next.t("modifier:enemyTurnHealApply", {
+      i18next.t("itemApply:enemyTurnHealApply", {
         pokemonNameWithAffix: getPokemonNameWithAffix(enemyPokemon),
       }),
       true,
@@ -159,12 +159,6 @@ export class EnemyEndureChanceTrainerItemAttr extends TrainerItemAttr<typeof Tra
 
   get iconName(): string {
     return "wl_reset_urge";
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.EnemyEndureChanceModifierType.description", {
-      chancePercent: this.chance,
-    });
   }
 
   public override apply({ pokemon: target }: PokemonParams, manager: TrainerItemManager): void {

--- a/src/items/trainer-items/exp-booster.ts
+++ b/src/items/trainer-items/exp-booster.ts
@@ -2,7 +2,6 @@ import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { NumberHolderParams } from "#types/trainer-item-parameter";
-import i18next from "i18next";
 
 export class ExpBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.EXP_BOOSTER> {
   public override readonly effect = TrainerItemEffect.EXP_BOOSTER;
@@ -12,12 +11,6 @@ export class ExpBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerIte
     super();
 
     this.boostPercent = boostPercent;
-  }
-
-  public get description(): string {
-    return i18next.t("modifierType:ModifierType.ExpBoosterModifierType.description", {
-      boostPercent: this.boostPercent,
-    });
   }
 
   public override apply({ numberHolder: boost }: NumberHolderParams, manager: TrainerItemManager): void {

--- a/src/items/trainer-items/x-items.ts
+++ b/src/items/trainer-items/x-items.ts
@@ -1,9 +1,8 @@
-import { getStatKey, Stat, type TempBattleStat } from "#enums/stat";
+import { Stat, type TempBattleStat } from "#enums/stat";
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
-import { TrainerItemId, TrainerItemNames } from "#enums/trainer-item-id";
+import { TrainerItemId } from "#enums/trainer-item-id";
 import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { NumberHolderParams } from "#types/trainer-item-parameter";
-import i18next from "i18next";
 
 export const tempStatToTrainerItem = {
   [Stat.ATK]: TrainerItemId.X_ATTACK,
@@ -16,27 +15,12 @@ export const tempStatToTrainerItem = {
 
 export class StatStageBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.TEMP_STAT_STAGE_BOOSTER> {
   public override readonly effect = TrainerItemEffect.TEMP_STAT_STAGE_BOOSTER;
-  private readonly stat: Exclude<TempBattleStat, Stat.ACC>;
   private readonly boost: number;
 
-  constructor(stat: Exclude<TempBattleStat, Stat.ACC>, boost: number) {
+  constructor(_stat: Exclude<TempBattleStat, Stat.ACC>, boost: number) {
     super();
 
-    this.stat = stat;
     this.boost = boost;
-  }
-
-  // TODO move to builder
-  get name(): string {
-    return i18next.t(`modifierType:TempStatStageBoosterItem.${TrainerItemNames[this.type]?.toLowerCase()}`);
-  }
-
-  get description(): string {
-    console.log();
-    return i18next.t("modifierType:ModifierType.TempStatStageBoosterModifierType.description", {
-      stat: i18next.t(getStatKey(this.stat)),
-      amount: i18next.t("modifierType:ModifierType.TempStatStageBoosterModifierType.extra.percentage"),
-    });
   }
 
   public override apply({ numberHolder: statLevel }: NumberHolderParams): void {
@@ -47,18 +31,6 @@ export class StatStageBoosterTrainerItemAttr extends TrainerItemAttr<typeof Trai
 export class AccuracyBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.TEMP_ACCURACY_BOOSTER> {
   public override readonly effect = TrainerItemEffect.TEMP_ACCURACY_BOOSTER;
 
-  get name(): string {
-    return i18next.t(`modifierType:TempStatStageBoosterItem.${TrainerItemNames[this.type]?.toLowerCase()}`);
-  }
-
-  get description(): string {
-    console.log();
-    return i18next.t("modifierType:ModifierType.TempStatStageBoosterModifierType.description", {
-      stat: i18next.t(getStatKey(Stat.ACC)),
-      amount: i18next.t("modifierType:ModifierType.TempStatStageBoosterModifierType.extra.percentage"),
-    });
-  }
-
   public override apply({ numberHolder: statLevel }: NumberHolderParams): void {
     const boost = 1;
     statLevel.value += boost;
@@ -67,13 +39,6 @@ export class AccuracyBoosterTrainerItemAttr extends TrainerItemAttr<typeof Train
 
 export class CritBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.TEMP_CRIT_BOOSTER> {
   public override readonly effect = TrainerItemEffect.TEMP_CRIT_BOOSTER;
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.TempStatStageBoosterModifierType.description", {
-      stat: i18next.t("modifierType:ModifierType.DIRE_HIT.extra.raises"),
-      amount: i18next.t("modifierType:ModifierType.TempStatStageBoosterModifierType.extra.stage"),
-    });
-  }
 
   public override apply({ numberHolder: critLevel }: NumberHolderParams): void {
     critLevel.value++;

--- a/src/system/unlockables.ts
+++ b/src/system/unlockables.ts
@@ -8,10 +8,10 @@ export function getUnlockableName(unlockable: Unlockables) {
     case Unlockables.ENDLESS_MODE:
       return i18next.t("gameMode:mode", { mode: GameMode.getModeName(GameModes.ENDLESS) });
     case Unlockables.MINI_BLACK_HOLE:
-      return i18next.t("modifierType:ModifierType.MINI_BLACK_HOLE.name");
+      return i18next.t("item:miniBlackHole.name");
     case Unlockables.SPLICED_ENDLESS_MODE:
       return i18next.t("gameMode:mode", { mode: GameMode.getModeName(GameModes.SPLICED_ENDLESS) });
     case Unlockables.EVIOLITE:
-      return i18next.t("modifierType:ModifierType.EVIOLITE.name");
+      return i18next.t("item:eviolite.name");
   }
 }

--- a/test/tests/mystery-encounter/encounters/field-trip-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/field-trip-encounter.test.ts
@@ -99,21 +99,11 @@ describe("Field Trip - Mystery Encounter", () => {
         h => h instanceof RewardSelectUiHandler,
       ) as RewardSelectUiHandler;
       expect(rewardSelectHandler.options.length).toEqual(5);
-      expect(rewardSelectHandler.options[0].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_attack"),
-      );
-      expect(rewardSelectHandler.options[1].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_defense"),
-      );
-      expect(rewardSelectHandler.options[2].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_speed"),
-      );
-      expect(rewardSelectHandler.options[3].rewardOption.type.name).toBe(
-        i18next.t("modifierType:ModifierType.DIRE_HIT.name"),
-      );
-      expect(rewardSelectHandler.options[4].rewardOption.type.name).toBe(
-        i18next.t("modifierType:ModifierType.RARER_CANDY.name"),
-      );
+      expect(rewardSelectHandler.options[0].rewardOption.type.name).toBe(i18next.t("item:xAttack.name"));
+      expect(rewardSelectHandler.options[1].rewardOption.type.name).toBe(i18next.t("item:xDefense.name"));
+      expect(rewardSelectHandler.options[2].rewardOption.type.name).toBe(i18next.t("item:xSpeed.name"));
+      expect(rewardSelectHandler.options[3].rewardOption.type.name).toBe(i18next.t("item:direHit.name"));
+      expect(rewardSelectHandler.options[4].rewardOption.type.name).toBe(i18next.t("reward:rarerCandy.name"));
     });
 
     it("should leave encounter without battle", async () => {
@@ -160,21 +150,11 @@ describe("Field Trip - Mystery Encounter", () => {
         h => h instanceof RewardSelectUiHandler,
       ) as RewardSelectUiHandler;
       expect(rewardSelectHandler.options.length).toEqual(5);
-      expect(rewardSelectHandler.options[0].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_sp_atk"),
-      );
-      expect(rewardSelectHandler.options[1].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_sp_def"),
-      );
-      expect(rewardSelectHandler.options[2].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_speed"),
-      );
-      expect(rewardSelectHandler.options[3].rewardOption.type.name).toBe(
-        i18next.t("modifierType:ModifierType.DIRE_HIT.name"),
-      );
-      expect(rewardSelectHandler.options[4].rewardOption.type.name).toBe(
-        i18next.t("modifierType:ModifierType.RARER_CANDY.name"),
-      );
+      expect(rewardSelectHandler.options[0].rewardOption.type.name).toBe(i18next.t("item:xSpAtk.name"));
+      expect(rewardSelectHandler.options[1].rewardOption.type.name).toBe(i18next.t("item:xSpDef.name"));
+      expect(rewardSelectHandler.options[2].rewardOption.type.name).toBe(i18next.t("item:xSpeed.name"));
+      expect(rewardSelectHandler.options[3].rewardOption.type.name).toBe(i18next.t("item:direHit.name"));
+      expect(rewardSelectHandler.options[4].rewardOption.type.name).toBe(i18next.t("reward:rarerCandy.name"));
     });
 
     it("should leave encounter without battle", async () => {
@@ -222,28 +202,17 @@ describe("Field Trip - Mystery Encounter", () => {
         h => h instanceof RewardSelectUiHandler,
       ) as RewardSelectUiHandler;
       expect(rewardSelectHandler.options.length).toEqual(5);
-      expect(rewardSelectHandler.options[0].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_accuracy"),
-      );
-      expect(rewardSelectHandler.options[1].rewardOption.type.name).toBe(
-        i18next.t("modifierType:TempStatStageBoosterItem.x_speed"),
-      );
+      expect(rewardSelectHandler.options[0].rewardOption.type.name).toBe(i18next.t("item:xAccuracy.name"));
+      expect(rewardSelectHandler.options[1].rewardOption.type.name).toBe(i18next.t("item:xSpeed.name"));
       expect(rewardSelectHandler.options[2].rewardOption.type.name).toBe(
-        i18next.t("modifierType:ModifierType.AddPokeballModifierType.name", {
+        i18next.t("reward:addPokeball.name", {
           modifierCount: 5,
           pokeballName: i18next.t("pokeball:greatBall"),
         }),
       );
-      expect(i18next.t).toHaveBeenCalledWith(
-        "modifierType:ModifierType.AddPokeballModifierType.name",
-        expect.objectContaining({ modifierCount: 5 }),
-      );
-      expect(rewardSelectHandler.options[3].rewardOption.type.name).toBe(
-        i18next.t("modifierType:ModifierType.IV_SCANNER.name"),
-      );
-      expect(rewardSelectHandler.options[4].rewardOption.type.name).toBe(
-        i18next.t("modifierType:ModifierType.RARER_CANDY.name"),
-      );
+      expect(i18next.t).toHaveBeenCalledWith("reward:addPokeball.name", expect.objectContaining({ modifierCount: 5 }));
+      expect(rewardSelectHandler.options[3].rewardOption.type.name).toBe(i18next.t("item:ivScanner.name"));
+      expect(rewardSelectHandler.options[4].rewardOption.type.name).toBe(i18next.t("reward:rarerCandy.name"));
     });
 
     it("should leave encounter without battle", async () => {

--- a/test/tests/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -302,14 +302,10 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
         h => h instanceof RewardSelectUiHandler,
       ) as RewardSelectUiHandler;
       expect(
-        rewardSelectHandler.options.some(
-          opt => opt.rewardOption.type.name === i18next.t("modifierType:AttackTypeBoosterItem.metal_coat"),
-        ),
+        rewardSelectHandler.options.some(opt => opt.rewardOption.type.name === i18next.t("item:metalCoat.name")),
       ).toBe(true);
       expect(
-        rewardSelectHandler.options.some(
-          opt => opt.rewardOption.type.name === i18next.t("modifierType:AttackTypeBoosterItem.magnet"),
-        ),
+        rewardSelectHandler.options.some(opt => opt.rewardOption.type.name === i18next.t("item:magnet.name")),
       ).toBe(true);
     });
   });


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Main repo side of the move from `modifier` to `item` locales, see https://github.com/pagefaultgames/pokerogue-locales/pull/352/

## What are the changes from a developer perspective?
Pretty much entirely removing unneeded overrides and updating to `item:camelCase` or `reward:camelCase` keys

## How to test the changes?
Not sure there's a good way here... play the game?