### PR TITLE
fix: priority immunity effects now block spread moves

### DIFF
--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -563,7 +563,7 @@ export interface FieldPriorityMoveImmunityAbAttrParams extends AugmentMoveIntera
 
 export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
   override canApply({ move, opponent: attacker, cancelled, pokemon }: FieldPriorityMoveImmunityAbAttrParams): boolean {
-    return (!cancelled.value && move.getPriority(attacker) > 0 && !move.isAllyTarget() && attacker.isOpponent(pokemon));
+    return !cancelled.value && move.getPriority(attacker) > 0 && !move.isAllyTarget() && attacker.isOpponent(pokemon);
   }
 
   override apply({ cancelled }: FieldPriorityMoveImmunityAbAttrParams): void {

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -563,12 +563,7 @@ export interface FieldPriorityMoveImmunityAbAttrParams extends AugmentMoveIntera
 
 export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
   override canApply({ move, opponent: attacker, cancelled, pokemon }: FieldPriorityMoveImmunityAbAttrParams): boolean {
-    return (
-      !cancelled.value
-      && move.getPriority(attacker) > 0
-      && !move.isAllyTarget()
-      && attacker.isOpponent(pokemon)
-    );
+    return (!cancelled.value && move.getPriority(attacker) > 0 && !move.isAllyTarget() && attacker.isOpponent(pokemon));
   }
 
   override apply({ cancelled }: FieldPriorityMoveImmunityAbAttrParams): void {

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -567,7 +567,6 @@ export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
       !cancelled.value
       && move.getPriority(attacker) > 0
       && !move.isAllyTarget()
-      && !move.isMultiTarget()
       && attacker.isOpponent(pokemon)
     );
   }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -488,7 +488,6 @@ export class Arena {
     if (this.terrainType === TerrainType.PSYCHIC) {
       return (
         !isFieldTargeted(move)
-        && !isSpreadMove(move)
         && move.getPriority(user) > 0
         && user.getOpponents(true).some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded())
       );

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -486,7 +486,7 @@ export class Arena {
   /** @see {@link https://bulbapedia.bulbagarden.net/wiki/Psychic_Terrain_(move)#Effect} */
   public isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move): boolean {
     if (this.terrainType === TerrainType.PSYCHIC) {
-      return (!isFieldTargeted(move) && move.getPriority(user) > 0 && user.getOpponents(true).some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded()));
+      return !isFieldTargeted(move) && move.getPriority(user) > 0 && user.getOpponents(true).some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded());
     }
     return false;
   }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -43,7 +43,7 @@ import {
 import type { Pokemon } from "#field/pokemon";
 import { FieldEffectModifier } from "#modifiers/modifier";
 import type { Move } from "#moves/move";
-import { isFieldTargeted, isSpreadMove } from "#moves/move-utils";
+import { isFieldTargeted } from "#moves/move-utils";
 import type { ArenaPokemonPools, TrainerPools } from "#types/biomes";
 import type { Constructor } from "#types/common";
 import type { RGBArray } from "#types/sprite-types";

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -486,11 +486,7 @@ export class Arena {
   /** @see {@link https://bulbapedia.bulbagarden.net/wiki/Psychic_Terrain_(move)#Effect} */
   public isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move): boolean {
     if (this.terrainType === TerrainType.PSYCHIC) {
-      return (
-        !isFieldTargeted(move)
-        && move.getPriority(user) > 0
-        && user.getOpponents(true).some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded())
-      );
+      return (!isFieldTargeted(move) && move.getPriority(user) > 0 && user.getOpponents(true).some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded()));
     }
     return false;
   }


### PR DESCRIPTION
## What are the changes the user will see?
Abilities that work like Dazzling will be able to block priority spread moves.
Psychic Terrain will block priority spread moves if at least one target is grounded.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
These changes make the affected mechanics in line with official games.

## What are the changes from a developer perspective?
The checks for spread moves in the files `arena.ts` and `terrain.ts` have been deleted. 
<!--
Describe the changes this PR introduces to the codebase.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc. have been added or changed?

Include enough detail to convey the scope of the changes being made and the rationale behind their implementation.
Feel free to include small code snippets if you think they will help illustrate your points.
-->

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
For Dazzling:
```
const overrides = {
      FIELD_SIZE_OVERRIDE: "double", STARTING_WAVE_OVERRIDE: 2,
      ABILITY_OVERRIDE: AbilityId.PRANKSTER , MOVESET_OVERRIDE: [MoveId.RAIN_DANCE, MoveId.DARK_VOID, MoveId.SKILL_SWAP],
      ENEMY_ABILITY_OVERRIDE: AbilityId.DAZZLING, ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH]} satisfies Partial<InstanceType<typeof DefaultOverrides>>; 
 ```
For Psychic Terrain:
```
const overrides = {
     FIELD_SIZE_OVERRIDE: "double", STARTING_WAVE_OVERRIDE: 2,
     PASSIVE_ABILITY_OVERRIDE: AbilityId.PSYCHIC_SURGE, ABILITY_OVERRIDE: AbilityId.PRANKSTER, MOVESET_OVERRIDE: [MoveId.RAIN_DANCE, MoveId.DARK_VOID, MoveId.SKILL_SWAP],
     ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH]} satisfies Partial<InstanceType<typeof DefaultOverrides>>; 
```
In both tests, Dark Void will correctly fail, like Skill Swap. Rain Dance is unaffected.
## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
