### PR TITLE
fix: priority immunity effects now block spread moves

### DIFF
--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -563,13 +563,7 @@ export interface FieldPriorityMoveImmunityAbAttrParams extends AugmentMoveIntera
 
 export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
   override canApply({ move, opponent: attacker, cancelled, pokemon }: FieldPriorityMoveImmunityAbAttrParams): boolean {
-    return (
-      !cancelled.value
-      && move.getPriority(attacker) > 0
-      && !move.isAllyTarget()
-      && !move.isMultiTarget()
-      && attacker.isOpponent(pokemon)
-    );
+    return !cancelled.value && move.getPriority(attacker) > 0 && !move.isAllyTarget() && attacker.isOpponent(pokemon);
   }
 
   override apply({ cancelled }: FieldPriorityMoveImmunityAbAttrParams): void {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -43,7 +43,7 @@ import {
 import type { Pokemon } from "#field/pokemon";
 import { FieldEffectModifier } from "#modifiers/modifier";
 import type { Move } from "#moves/move";
-import { isFieldTargeted, isSpreadMove } from "#moves/move-utils";
+import { isFieldTargeted } from "#moves/move-utils";
 import type { ArenaPokemonPools, TrainerPools } from "#types/biomes";
 import type { Constructor } from "#types/common";
 import type { RGBArray } from "#types/sprite-types";
@@ -473,7 +473,6 @@ export class Arena {
     if (this.terrainType === TerrainType.PSYCHIC) {
       return (
         !isFieldTargeted(move)
-        && !isSpreadMove(move)
         && move.getPriority(user) > 0
         && user.getOpponents(true).some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded())
       );

--- a/test/tests/abilities/priority-prevention.test.ts
+++ b/test/tests/abilities/priority-prevention.test.ts
@@ -16,6 +16,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 describe.each([
   { abilityId: AbilityId.DAZZLING, abilityName: "Dazzling" },
   { abilityId: AbilityId.QUEENLY_MAJESTY, abilityName: "Queenly Majesty" },
+  { abilityId: AbilityId.ARMOR_TAIL, abilityName: "Armor Tail" },
 ])("Ability - $abilityName", ({ abilityId }) => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -46,6 +47,16 @@ describe.each([
     await game.toEndOfTurn();
 
     expect(game.field.getPlayerPokemon()).toHaveUsedMove({ move: MoveId.QUICK_ATTACK, result: MoveResult.FAIL });
+  });
+
+  it("should block enemy multi-target increased priority moves", async () => {
+    game.override.ability(AbilityId.TRIAGE);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.MATCHA_GOTCHA);
+    await game.toEndOfTurn();
+
+    expect(game.field.getPlayerPokemon()).toHaveUsedMove({ move: MoveId.MATCHA_GOTCHA, result: MoveResult.FAIL });
   });
 
   describe("Doubles Interactions", () => {

--- a/test/tests/arena/terrain.test.ts
+++ b/test/tests/arena/terrain.test.ts
@@ -10,7 +10,6 @@ import { MoveResult } from "#enums/move-result";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/framework/game-manager";
 import { toTitleCase } from "#utils/strings";
 import i18next from "i18next";
@@ -351,32 +350,26 @@ describe("Terrain -", () => {
       );
     });
 
-    it.each<{ category: string; move: MoveId; effect: () => void }>([
-      {
-        category: "Field-targeted",
-        move: MoveId.RAIN_DANCE,
-        effect: () => {
-          expect(game).toHaveWeather(WeatherType.RAIN);
-        },
-      },
-      {
-        // TODO: Review if this is actually how it works in mainline
-        category: "Enemy-targeting spread",
-        move: MoveId.DARK_VOID,
-        effect: () => {
-          expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.SLEEP);
-        },
-      },
-    ])("should not block $category moves that become priority", async ({ move, effect }) => {
+    it("should not block 'Field-targeted' moves that become priority", async () => {
+      game.override.ability(AbilityId.PRANKSTER).enemyAbility(AbilityId.PRANKSTER);
       await game.classicMode.startBattle(SpeciesId.BLISSEY);
 
-      game.move.use(move);
-      await game.move.forceEnemyMove(MoveId.SPLASH);
+      game.move.use(MoveId.RAIN_DANCE);
       await game.toEndOfTurn();
 
       const blissey = game.field.getPlayerPokemon();
-      expect(blissey).toHaveUsedMove({ move, result: MoveResult.SUCCESS });
-      effect();
+      expect(blissey).toHaveUsedMove({ move: MoveId.RAIN_DANCE, result: MoveResult.SUCCESS });
+    });
+
+    it("should block 'Enemy-targeting spread' moves that become priority", async () => {
+      game.override.ability(AbilityId.PRANKSTER).enemyAbility(AbilityId.PRANKSTER);
+      await game.classicMode.startBattle(SpeciesId.BLISSEY);
+
+      game.move.use(MoveId.DARK_VOID);
+      await game.toEndOfTurn();
+
+      const blissey = game.field.getPlayerPokemon();
+      expect(blissey).toHaveUsedMove({ move: MoveId.DARK_VOID, result: MoveResult.FAIL });
     });
 
     it("should not block non-priority moves boosted by Quick Claw/Quick Draw", async () => {


### PR DESCRIPTION


## What are the changes the user will see?
Psychic Terrain and abilities that block opposing priority (Dazzling, Queenly Majesty, Armor Tail) should now block spread moves.
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Spread moves ignoring priority immunity effects is a bug. Proof here:
https://discord.com/channels/1125469663833370665/1409518614670868491/1455559590707068958
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->

## What are the changes from a developer perspective?
`ab.attrs.` and `arena.ts` have been modified accordingly, removing the condition at fault in their respective methods. Removed `isSpread` import in `arena.ts` since it went unused.
Added a new check to `terrain.tests.ts` and `priority-prevention.test.ts` to test that spread moves fail under these conditions. An Armor Tail test was also added to the latter file.

<!--
Describe the changes this PR introduces to the codebase.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc. have been added or changed?

Include enough detail to convey the scope of the changes being made and the rationale behind their implementation.
Feel free to include small code snippets if you think they will help illustrate your points.
-->

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>




</details>
<details><summary>After</summary>

https://github.com/user-attachments/assets/dfb0feb3-3212-4e0b-87be-9666680b92b0


[after screenshot here]

</details>
-->
<details><summary>Before</summary>

https://github.com/user-attachments/assets/a4cb416a-f5ff-459b-b952-3b3ae6f166db

</details>
<details><summary>After</summary>

https://github.com/user-attachments/assets/cf3220b1-0115-430d-8688-d64ff1f509d2

</details>

## How to test the changes?
### Manually
Using the `src/overrides.ts` file:
```
const overrides = {
  PASSIVE_ABILITY_OVERRIDE: AbilityId.DAZZLING,
  ABILITY_OVERRIDE: AbilityId.PRANKSTER,
  MOVESET_OVERRIDE: [MoveId.SWEET_SCENT, MoveId.PSYCHIC_TERRAIN],
  ENEMY_SPECIES_OVERRIDE: SpeciesId.SINISTCHA,
  ENEMY_ABILITY_OVERRIDE: AbilityId.TRIAGE,
  ENEMY_MOVESET_OVERRIDE: [MoveId.MATCHA_GOTCHA],
} satisfies Partial<InstanceType<OverridesType>>;
```
Simply use Psychic Terrain, then Sweet Scent: the enemy's Matcha Gotcha should fail due to Dazzling on the first turn, your Sweet Scent should fail due to Psychic Terrain on the second turn.

### Automatically
Using the files `test/tests/terrain.test.ts` and `test/tests/priority-prevention.test.ts`.
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
