### PR TITLE
misc: fix incorrect typing for `TrappedTag.tagType`

### DIFF
--- a/src/@types/battler-tags.ts
+++ b/src/@types/battler-tags.ts
@@ -21,6 +21,7 @@ export type MoveRestrictionBattlerTagType =
  * Subset of {@linkcode BattlerTagType}s that are related to trapping effects.
  */
 export type TrappingBattlerTagType =
+  | BattlerTagType.TRAPPED
   | BattlerTagType.BIND
   | BattlerTagType.WRAP
   | BattlerTagType.FIRE_SPIN

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -279,7 +279,7 @@ export class SerializableBattlerTag extends BattlerTag {
  * @see BattlerTagTypeMap
  */
 interface GenericSerializableBattlerTag<T extends BattlerTagType> extends SerializableBattlerTag {
-  tagType: T;
+  readonly tagType: T;
 }
 
 /**

--- a/test/tests/moves/jaw-lock.test.ts
+++ b/test/tests/moves/jaw-lock.test.ts
@@ -42,8 +42,8 @@ describe("Moves - Jaw Lock", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase", false);
 
-    expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
+    expect(leadPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
+    expect(enemyPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
 
     await game.phaseInterceptor.to("TurnEndPhase");
 
@@ -63,18 +63,18 @@ describe("Moves - Jaw Lock", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase", false);
 
-    expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
+    expect(leadPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
+    expect(enemyPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
 
     await game.phaseInterceptor.to("MoveEffectPhase");
 
-    expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
+    expect(leadPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
+    expect(enemyPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
 
     await game.phaseInterceptor.to("FaintPhase");
 
-    expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
+    expect(leadPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
+    expect(enemyPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
   });
 
   it("should only trap the user until the target faints", async () => {
@@ -95,7 +95,7 @@ describe("Moves - Jaw Lock", () => {
 
     await game.doKillOpponents();
 
-    expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
+    expect(leadPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
   });
 
   it("should not trap other targets after the first target is trapped", async () => {
@@ -123,9 +123,8 @@ describe("Moves - Jaw Lock", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase");
 
-    expect(enemyPokemon[1].getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    expect(playerPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
-    expect(playerPokemon.getTag(BattlerTagType.TRAPPED)?.sourceId).toBe(enemyPokemon[0].id);
+    expect(enemyPokemon[1]).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
+    expect(playerPokemon).toHaveBattlerTag({ tagType: BattlerTagType.TRAPPED, sourceId: enemyPokemon[0].id });
   });
 
   it("should not trap either pokemon if the target is protected", async () => {
@@ -140,7 +139,7 @@ describe("Moves - Jaw Lock", () => {
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(playerPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
+    expect(playerPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
+    expect(enemyPokemon).not.toHaveBattlerTag(BattlerTagType.TRAPPED);
   });
 });

--- a/test/tests/types/arena-tags.test-d.ts
+++ b/test/tests/types/arena-tags.test-d.ts
@@ -1,0 +1,12 @@
+import type { ArenaTagTypeMap } from "#data/arena-tag";
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("ArenaTags", () => {
+  it("should contain tagTypes compatible with the key given in ArenaTagTypeMap", () => {
+    type IncompatibleArenaTagTypeMapKeys = {
+      [K in keyof ArenaTagTypeMap]: K extends ArenaTagTypeMap[K]["tagType"] ? never : K;
+    }[keyof ArenaTagTypeMap];
+
+    expectTypeOf<IncompatibleArenaTagTypeMapKeys>().toBeNever();
+  });
+});

--- a/test/tests/types/battler-tags.test-d.ts
+++ b/test/tests/types/battler-tags.test-d.ts
@@ -1,0 +1,12 @@
+import type { BattlerTagTypeMap } from "#data/battler-tags";
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("BattlerTags", () => {
+  it("should contain tagTypes compatible with the key given in BattlerTagTypeMap", () => {
+    type IncompatibleBattlerTagTypeMapKeys = {
+      [K in keyof BattlerTagTypeMap]: K extends BattlerTagTypeMap[K]["tagType"] ? never : K;
+    }[keyof BattlerTagTypeMap];
+
+    expectTypeOf<IncompatibleBattlerTagTypeMapKeys>().toBeNever();
+  });
+});


### PR DESCRIPTION

## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Editing the Jaw Lock tests to use matchers produced a type error from `TrappedTag#tagType` not including `BattlerTagType.TRAPPED` (the key to which it was mapped in `BattlerTagTypeMap`).
This produced an incompatible intersection type that resolved to `never`.

## What are the changes from a developer perspective?
Fixed the typing issue and added a pair of type tests to ensure this will never happen again.

## Screenshots/Videos
N/A
## How to test the changes?
`pnpm exec tsgo`
## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary