### PR TITLE
test: Fix bug in `toHaveTypes` matcher

### DIFF
--- a/test/matchers/to-have-types.ts
+++ b/test/matchers/to-have-types.ts
@@ -91,12 +91,21 @@ export function toHaveTypes(
     };
   }
 
-  // Exact matches do not care about subset equality
-  const matchers =
-    mode === "superset"
-      ? [...this.customTesters, this.utils.iterableEquality]
-      : [...this.customTesters, this.utils.subsetEquality, this.utils.iterableEquality];
-  const pass = this.equals(actualSorted, expectedSorted, matchers);
+  if (mode === "superset") {
+    const pass = expectedSorted.every(v => actualSorted.some(a => this.equals(a, v)));
+
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `Expected ${pkmName}'s types NOT to include all of ${expectedStr}, but it did!`
+          : `Expected ${pkmName}'s types to include all of ${expectedStr}, but it didn't!`,
+      expected: expectedSorted,
+      actual: actualSorted,
+    };
+  }
+
+  const pass = this.equals(actualSorted, expectedSorted, [...this.customTesters, this.utils.iterableEquality]);
 
   return {
     pass,


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
There was a bug that effectively made the "subset" mode of the `toHaveTypes` matcher useless.

## What are the changes from a developer perspective?
Fixed the bug
## How to test the changes?
Can't ATM, since no tests use it... just check the code

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary