### PR TITLE
dev: prevent `npm` from being used to install packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -56,6 +56,7 @@ path = [
     "pnpm-workspace.yaml",
     # Miscellaneous files of insignificant originality
     ".nvmrc",
+    ".npmrc",
     "RELEASE",
     # patch files for broken packages
     "patches/*.patch"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,18 @@
     "@actions/github": "^9.1.1",
     "octokit": "^5.0.5"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.34.5",
+      "onFail": "download"
+    },
+    "runtime": {
+      "name": "node",
+      "version": ">=24.9.0",
+      "onFail": "warn"
+    }
+  },
   "engines": {
     "node": ">=24.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,97 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 10.34.5
+        version: 10.34.5
+      pnpm:
+        specifier: 10.34.5
+        version: 10.34.5
+
+packages:
+
+  '@pnpm/exe@10.34.5':
+    resolution: {integrity: sha512-u2moSd4OWIszfle+clb+i04fD2lSWYHyrOLjEoJfM9WFtdgkWBFGq1sdnRvH/1KsEyglmIz3daC7cdqu+uz59w==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@10.34.5':
+    resolution: {integrity: sha512-sV8iFna/MN7BMDuBmAEJqhzlywAoJ8LXXjrMR3IkeoDtP9PBY5j/AkGHa9woVDZMAEIAMxWV7sBnyPxiN5ByGA==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/linux-x64@10.34.5':
+    resolution: {integrity: sha512-blNFcW3EVmOkeZYnkY5lraD1+oqiFvSByMT3GTRGKp7P7C4PtHixLQJLe2AzJ4rLimFjgqfHg0Cf/Si/9bZlHQ==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/macos-arm64@10.34.5':
+    resolution: {integrity: sha512-Uxvslz0yx/IICmP0EoGs+H9j4cA3JXV0mjtvAOisht0y/FCjS1GkGj8BA+EudDwmc9vsgtOrnq6tRFRluCsIsA==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/macos-x64@10.34.5':
+    resolution: {integrity: sha512-KrvYm3ArCMCT/rZnBUYPC6phvWxowpgJzIa/19UY4/2GL0L4CGUX8sGB30qI1lae1numn/6s2VkSCFF4VrZuyg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/win-arm64@10.34.5':
+    resolution: {integrity: sha512-r7fdkZEmIJzXXZMrOfu2j2sUmLlLvuXVJ48NER6bT/UtaIIZYXTUNy6/ejYLxf2PBqyOruhjYmVqkJthk6v1yA==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@pnpm/win-x64@10.34.5':
+    resolution: {integrity: sha512-bMjuj4KrPeqLqb66AS1ABqbbjow3JW0odFil70HC+PAwVM0meACH2Alv3IfrrxKgoO/yqCpOIttesT/tVbsOSA==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  pnpm@10.34.5:
+    resolution: {integrity: sha512-pO4F8vc2WCVb1qiYWcBlpFwopX2u+uLIk6Fo7itzFow3uR6D5X6mdlStA/AwMXRkMOi84442LgQmBfuKvIAZLg==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@10.34.5':
+    optionalDependencies:
+      '@pnpm/linux-arm64': 10.34.5
+      '@pnpm/linux-x64': 10.34.5
+      '@pnpm/macos-arm64': 10.34.5
+      '@pnpm/macos-x64': 10.34.5
+      '@pnpm/win-arm64': 10.34.5
+      '@pnpm/win-x64': 10.34.5
+
+  '@pnpm/linux-arm64@10.34.5':
+    optional: true
+
+  '@pnpm/linux-x64@10.34.5':
+    optional: true
+
+  '@pnpm/macos-arm64@10.34.5':
+    optional: true
+
+  '@pnpm/macos-x64@10.34.5':
+    optional: true
+
+  '@pnpm/win-arm64@10.34.5':
+    optional: true
+
+  '@pnpm/win-x64@10.34.5':
+    optional: true
+
+  pnpm@10.34.5: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,5 @@ patchedDependencies:
 shellEmulator: true
 
 dedupePeers: true
+
+engineStrict: false # required because pnpm10 obeys settings in `.npmrc` if no value is specified in this file


### PR DESCRIPTION
> [!NOTE]
> Draft until Dependabot is updated to properly parse 2-document `pnpm-lock.yaml` files (otherwise the security alerts feature won't work).

## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Prevent mistakes from new contributors that don't know we use `pnpm` instead of `npm`.

## What are the changes from a developer perspective?
- Set `devEngines.packageManager.name` to `"pnpm"` and `.onFail` to `"download"` in `package.json`.
- Set `engine-strict = true` in `.npmrc` so that npm will obey the settings in `package.json`.
- Set `engineStrict: false` in `pnpm-workspace.yaml` due to pnpm10 obeying settings from `.npmrc` if they're not overridden in `pnpm-workspace.yaml`.

## How to test the changes?
Try running `npm install` and you should get an error message.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually