### PR TITLE
misc: break up `Pokemon#calculateStats` + minor assorted fixes

### DIFF
--- a/src/data/nature.ts
+++ b/src/data/nature.ts
@@ -1,5 +1,5 @@
 import { Nature } from "#enums/nature";
-import { EFFECTIVE_STATS, getShortenedStatKey, Stat } from "#enums/stat";
+import { EFFECTIVE_STATS, type EffectiveStat, getShortenedStatKey, Stat } from "#enums/stat";
 import { TextStyle } from "#enums/text-style";
 import { getBBCodeFrag } from "#ui/text";
 import { toCamelCase } from "#utils/strings";
@@ -40,7 +40,7 @@ export function getNatureName(
   return ret;
 }
 
-export function getNatureStatMultiplier(nature: Nature, stat: Stat): number {
+export function getNatureStatMultiplier(nature: Nature, stat: EffectiveStat): number {
   switch (stat) {
     case Stat.ATK:
       switch (nature) {
@@ -113,6 +113,5 @@ export function getNatureStatMultiplier(nature: Nature, stat: Stat): number {
       }
       break;
   }
-
   return 1;
 }

--- a/src/enums/stat.ts
+++ b/src/enums/stat.ts
@@ -23,20 +23,24 @@ export enum Stat {
 
 /** A constant array comprised of the {@linkcode Stat} values that make up {@linkcode PermanentStat}. */
 export const PERMANENT_STATS = [Stat.HP, Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD] as const;
-/** Type used to describe the core, permanent stats of a Pokemon. */
+/** Type used to describe the core stats of a Pokemon which are persisted between battles. */
 export type PermanentStat = (typeof PERMANENT_STATS)[number];
 
 /** A constant array comprised of the {@linkcode Stat} values that make up {@linkcode EFfectiveStat}. */
 export const EFFECTIVE_STATS = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD] as const;
-/** Type used to describe the intersection of core stats and stats that have stages in battle. */
+/**
+ * Type used to describe the intersection of core stats and stats that have stages in battle:
+ * ATK, DEF, SPATK, SPDEF, and SPD. \
+ * (These are also the ones affected by Natures.)
+ */
 export type EffectiveStat = (typeof EFFECTIVE_STATS)[number];
 
-/** A constant array comprised of {@linkcode Stat} the values that make up {@linkcode BattleStat}. */
+/** A constant array comprised of the {@linkcode Stat} values that make up {@linkcode BattleStat}. */
 export const BATTLE_STATS = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD, Stat.ACC, Stat.EVA] as const;
 /** Type used to describe the stats that have stages which can be incremented and decremented in battle. */
 export type BattleStat = (typeof BATTLE_STATS)[number];
 
-/** A constant array comprised of {@linkcode Stat} the values that make up {@linkcode TempBattleStat}. */
+/** A constant array comprised of the {@linkcode Stat} values that make up {@linkcode TempBattleStat}. */
 export const TEMP_BATTLE_STATS = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD, Stat.ACC] as const;
 /** Type used to describe the stats that have X item (`TEMP_STAT_STAGE_BOOSTER`) equivalents. */
 export type TempBattleStat = (typeof TEMP_BATTLE_STATS)[number];

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -187,7 +187,7 @@ import { QuantizerCelebi } from "@material/material-color-utilities";
 import i18next from "i18next";
 import Phaser from "phaser";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
-import type { NonEmptyTuple, Writable } from "type-fest";
+import type { NonEmptyTuple, TupleOf, Writable } from "type-fest";
 import type { LevelMoveContext } from "../@types/level-moves";
 import { getBaseLearnableMoveSource, getLevelMoves } from "./learnsets";
 
@@ -1407,6 +1407,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param stat - The {@linkcode BattleStat} whose stage is to be overwritten
    * @param value - The value of the stat stage to set, forcibly clamped within the range `[-6, +6]`.
    */
+  // TODO: Don't clamp the value, change the allowed type instead
   setStatStage(stat: BattleStat, value: number): void {
     this.summonData.statStages[stat - 1] = Phaser.Math.Clamp(value, -6, 6);
   }
@@ -1449,15 +1450,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Calculates and retrieves the final value of a stat considering any held
-   * items, move effects, opponent abilities, and whether there was a critical
-   * hit.
+   * Calculate the final value of a given {@linkcode EffectiveStat}. Considers all effects that might
+   * modify the final calculation, including held items, move effects, critical hit-related effects, etc.
    *
    * @param stat - The desired stat to check
    * @param __namedParameters.opponent - Needed for proper typedoc rendering
    * @returns The final in-battle value for the given stat.
    */
-  // TODO: Replace the optional parameters with an object to make calling this method less cumbersome
   getEffectiveStat(
     stat: EffectiveStat,
     {
@@ -1500,7 +1499,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         stat,
         statVal,
         simulated,
-        // TODO: maybe just don't call this if the move is none?
+        // TODO: This is solely used by hustle for move accuracy reduction;
+        // none of the actual classes use it at all
         move: move ?? allMoves[MoveId.NONE],
       });
     }
@@ -1577,50 +1577,30 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return Math.max(Math.floor(ret), 1);
   }
 
+  /**
+   * Re-compute this Pokemon's permanent stats (before in-battle multipliers).
+   */
   calculateStats(): void {
-    if (!this.stats) {
-      this.stats = [0, 0, 0, 0, 0, 0];
-    }
-
-    // Get and manipulate base stats
     const baseStats = this.calculateBaseStats();
-    // Using base stats, calculate and store stats one by one
-    for (const s of PERMANENT_STATS) {
-      const statHolder = new NumberHolder(Math.floor((2 * baseStats[s] + this.ivs[s]) * this.level * 0.01));
-      if (s === Stat.HP) {
-        statHolder.value = statHolder.value + this.level + 10;
-        globalScene.applyModifier(PokemonIncrementingStatModifier, this.isPlayer(), this, s, statHolder);
-        if (this.hasAbility(AbilityId.WONDER_GUARD, false, true)) {
-          statHolder.value = 1;
+
+    for (const stat of PERMANENT_STATS) {
+      const value = this.calculateStat(stat, baseStats[stat], this.ivs[stat]);
+
+      // clamp HP to new max or restore current HP if max HP increased
+      if (stat === Stat.HP && !this.isFainted()) {
+        this.hp = Math.max(this.hp, value);
+
+        const lastMaxHp = this.getMaxHp();
+        if (lastMaxHp > 0 && value > lastMaxHp) {
+          this.hp += value - lastMaxHp;
         }
-        if (this.hp > statHolder.value || this.hp === undefined) {
-          this.hp = statHolder.value;
-        } else if (this.hp) {
-          const lastMaxHp = this.getMaxHp();
-          if (lastMaxHp && statHolder.value > lastMaxHp) {
-            this.hp += statHolder.value - lastMaxHp;
-          }
-        }
-      } else {
-        statHolder.value += 5;
-        const natureStatMultiplier = new NumberHolder(getNatureStatMultiplier(this.getNature(), s));
-        globalScene.applyModifier(PokemonNatureWeightModifier, this.isPlayer(), this, natureStatMultiplier);
-        if (natureStatMultiplier.value !== 1) {
-          statHolder.value = Math.max(
-            Math[natureStatMultiplier.value > 1 ? "ceil" : "floor"](statHolder.value * natureStatMultiplier.value),
-            1,
-          );
-        }
-        globalScene.applyModifier(PokemonIncrementingStatModifier, this.isPlayer(), this, s, statHolder);
       }
 
-      statHolder.value = Phaser.Math.Clamp(statHolder.value, 1, Number.MAX_SAFE_INTEGER);
-
-      this.setStat(s, statHolder.value);
+      this.setStat(stat, value);
     }
   }
 
-  calculateBaseStats(): number[] {
+  private calculateBaseStats(): TupleOf<typeof PERMANENT_STATS.length, number> {
     const baseStats = this.getSpeciesForm(true).baseStats.slice(0);
     applyChallenges(ChallengeType.FLIP_STAT, this, baseStats);
     // Shuckle Juice
@@ -1642,7 +1622,41 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // Vitamins
     globalScene.applyModifiers(BaseStatModifier, this.isPlayer(), this, baseStats);
 
-    return baseStats;
+    // TODO: Once the item rework is merged, convert function to use Array#map using the declaration merge and remove type assertion
+    return baseStats as TupleOf<typeof PERMANENT_STATS.length, number>;
+  }
+
+  /**
+   * Calculate the value of a single stat for a Pokemon.
+   * @param stat - The stat to calculate
+   * @param baseStat - The base stat value for the Pokemon's species
+   * @param iv - The Pokemon's IV for the given stat
+   * @returns The calculated stat value, which will be a positive integer less than {@linkcode Number.MAX_SAFE_INTEGER}.
+   * @see {@link https://bulbapedia.bulbagarden.net/wiki/Stat#Generation_III_onward | Bulbapedia: Stat calculation formula}
+   */
+  private calculateStat(stat: PermanentStat, baseStat: number, iv: number): number {
+    // Pokemon with Wonder Guard
+    if (stat === Stat.HP && this.hasAbility(AbilityId.WONDER_GUARD, false, true)) {
+      return 1;
+    }
+
+    // ((2 * Base + IV) * Level / 100) + (5 for non-HP, Level + 10 for HP)
+    let base =
+      Math.floor(((2 * baseStat + iv) * this.level) / 100) // formatting
+      + (stat === Stat.HP ? this.level + 10 : 5);
+
+    const statHolder = new ValueHolder(base);
+    if (stat !== Stat.HP) {
+      // the effect of natures is always rounded up (away from 0)
+      const natureMulti = new ValueHolder(getNatureStatMultiplier(this.getNature(), stat));
+      globalScene.applyModifier(PokemonNatureWeightModifier, this.isPlayer(), this, natureMulti);
+      const delta = Phaser.Math.RoundAwayFromZero(base * (natureMulti.value - 1));
+      base += delta;
+    }
+
+    globalScene.applyModifier(PokemonIncrementingStatModifier, this.isPlayer(), this, stat, statHolder);
+
+    return Phaser.Math.Clamp(statHolder.value, 1, Number.MAX_SAFE_INTEGER);
   }
 
   // TODO: Convert this into a getter
@@ -2371,8 +2385,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Accounts for all the various effects which can disable or modify abilities.
    * @param ability - The {@linkcode AbilityId | Ability} to check for
    * @param canApply - Whether to check if the ability is currently active; default `true`
-   * @param ignoreOverride - Whether to ignore any overrides caused by {@linkcode MoveId.TRANSFORM | Transform}; default `false`
-   * @returns Whether this {@linkcode Pokemon} has the given ability
+   * @param ignoreOverride - (Default `false`) Whether to respect any ability overrides caused by effects like
+   * {@linkcode MoveId.TRANSFORM | Transform} and {@linkcode MoveId.SKILL_SWAP | Skill Swap}
+   * @returns Whether this {@linkcode Pokemon} has the given ability.
    */
   public hasAbility(ability: AbilityId, canApply = true, ignoreOverride = false): boolean {
     if (this.getAbility(ignoreOverride).id === ability && (!canApply || this.canApplyAbility())) {
@@ -7138,16 +7153,14 @@ export class EnemyPokemon extends Pokemon {
         continue;
       }
 
-      let stages = 1;
+      // final segment gives +2 if 3 or more total segments exist;
+      // 2nd to last similarly gives +2 if 5 or more total segments exist
+      const stages =
+        (this.bossSegmentIndex === 0 && this.bossSegments >= 3)
+        || (this.bossSegmentIndex === 1 && this.bossSegments >= 5)
+          ? 2
+          : 1;
 
-      // increase the boost if the boss has at least 3 segments and we passed last shield
-      if (this.bossSegments >= 3 && this.bossSegmentIndex === 0) {
-        stages++;
-      }
-      // increase the boost if the boss has at least 5 segments and we passed the second to last shield
-      if (this.bossSegments >= 5 && this.bossSegmentIndex === 1) {
-        stages++;
-      }
       changes.push({ stat: boostedStat, stages });
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1635,7 +1635,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @see {@link https://bulbapedia.bulbagarden.net/wiki/Stat#Generation_III_onward | Bulbapedia: Stat calculation formula}
    */
   private calculateStat(stat: PermanentStat, baseStat: number, iv: number): number {
-    // Pokemon with Wonder Guard
+    // Pokemon with Wonder Guard as a base ability always have 1 HP
     if (stat === Stat.HP && this.hasAbility(AbilityId.WONDER_GUARD, false, true)) {
       return 1;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -217,7 +217,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public level: number;
   public exp: number;
   public gender: Gender;
-  public hp = 0;
+  public hp: number;
   // TODO: make tuple
   public stats: number[] = [0, 0, 0, 0, 0, 0];
   // todo: make a tuple from 0-31
@@ -402,6 +402,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.isTerastallized = dataSource.isTerastallized;
       this.stellarTypesBoosted = dataSource.stellarTypesBoosted ?? [];
     } else {
+      // TODO: this.hp is undefined right now
       this.id = randSeedInt(4294967296);
       this.ivs = ivs || getIvsFromId(this.id);
 
@@ -1588,16 +1589,21 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     for (const stat of PERMANENT_STATS) {
       const value = this.calculateStat(stat, baseStats[stat], this.ivs[stat]);
 
-      // clamp HP to new max or restore current HP if max HP increased
-      if (stat === Stat.HP && !this.isFainted()) {
-        this.hp = Math.min(this.hp, value);
-
-        const lastMaxHp = this.getMaxHp();
-        if (lastMaxHp > 0 && value > lastMaxHp) {
-          this.hp += value - lastMaxHp;
-        }
+      if (stat !== Stat.HP) {
+        this.setStat(stat, value);
+        continue;
       }
 
+      // clamp HP to new max or restore current HP if max HP increased
+
+      // optional chain defaults HP to max HP if not set yet
+      // TODO: this is extremely stupid
+      this.hp = Math.min(this.hp ?? value, value);
+
+      const lastMaxHp = this.getMaxHp();
+      if (lastMaxHp > 0 && value > lastMaxHp) {
+        this.hp += value - lastMaxHp;
+      }
       this.setStat(stat, value);
     }
   }
@@ -1633,7 +1639,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param stat - The stat to calculate
    * @param baseStat - The base stat value for the Pokemon's species
    * @param iv - The Pokemon's IV for the given stat
-   * @returns The calculated stat value, which will be a positive integer less than {@linkcode Number.MAX_SAFE_INTEGER}.
+   * @returns The calculated stat value, which will be a positive integer no greater than {@linkcode Number.MAX_SAFE_INTEGER}.
    * @see {@link https://bulbapedia.bulbagarden.net/wiki/Stat#Generation_III_onward | Bulbapedia: Stat calculation formula}
    */
   private calculateStat(stat: PermanentStat, baseStat: number, iv: number): number {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -217,8 +217,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public level: number;
   public exp: number;
   public gender: Gender;
-  public hp: number;
-  public stats: number[];
+  public hp = 0;
+  // TODO: make tuple
+  public stats: number[] = [0, 0, 0, 0, 0, 0];
+  // todo: make a tuple from 0-31
   public ivs: number[];
   public nature: Nature;
   public moveset: PokemonMove[];
@@ -1588,7 +1590,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
       // clamp HP to new max or restore current HP if max HP increased
       if (stat === Stat.HP && !this.isFainted()) {
-        this.hp = Math.max(this.hp, value);
+        this.hp = Math.min(this.hp, value);
 
         const lastMaxHp = this.getMaxHp();
         if (lastMaxHp > 0 && value > lastMaxHp) {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -28,7 +28,7 @@ import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesFormKey } from "#enums/species-form-key";
 import { SpeciesId } from "#enums/species-id";
 import type { PermanentStat, TempBattleStat } from "#enums/stat";
-import { getStatKey, Stat, TEMP_BATTLE_STATS } from "#enums/stat";
+import { EFFECTIVE_STATS, getStatKey, Stat, TEMP_BATTLE_STATS } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { VoucherType } from "#enums/voucher-type";
 import type { EnemyPokemon, PlayerPokemon, Pokemon } from "#field/pokemon";
@@ -124,7 +124,7 @@ import { PartyUiHandler } from "#ui/party-ui-handler";
 import { getModifierTierTextTint } from "#ui/text";
 import { applyChallenges } from "#utils/challenge-utils";
 import { BooleanHolder, formatMoney, NumberHolder, randSeedInt, randSeedItem } from "#utils/common";
-import { getEnumKeys, getEnumValues } from "#utils/enums";
+import { getEnumValues } from "#utils/enums";
 import { getPokemonTypeLocaleKey } from "#utils/i18n";
 import { getModifierPoolForType, getModifierType } from "#utils/modifier-utils";
 import i18next from "i18next";
@@ -689,13 +689,10 @@ export class PokemonNatureChangeModifierType extends PokemonModifierType {
   protected nature: Nature;
 
   constructor(nature: Nature) {
+    const boostedStat = EFFECTIVE_STATS.find(s => getNatureStatMultiplier(nature, s) > 1);
     super(
       "",
-      `mint_${
-        getEnumKeys(Stat)
-          .find(s => getNatureStatMultiplier(nature, Stat[s]) > 1)
-          ?.toLowerCase() || "neutral"
-      }`,
+      `mint_${boostedStat ? Stat[boostedStat].toLowerCase() : "neutral"}`,
       (_type, args) => new PokemonNatureChangeModifier(this, (args[0] as PlayerPokemon).id, this.nature),
       (pokemon: PlayerPokemon) => {
         if (pokemon.getNature() === this.nature) {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -283,7 +283,7 @@ export class UI extends Phaser.GameObjects.Container {
 
   public showTextPromise(text: string, callbackDelay = 0, prompt = true, promptDelay?: number | null): Promise<void> {
     return new Promise<void>(resolve => {
-      this.showText(text ?? "", null, () => resolve(), callbackDelay, prompt, promptDelay);
+      this.showText(text ?? "", null, resolve, callbackDelay, prompt, promptDelay);
     });
   }
 

--- a/test/setup/vitest.setup.ts
+++ b/test/setup/vitest.setup.ts
@@ -134,3 +134,12 @@ afterEach(context => {
 });
 
 // #endregion Hooks
+
+// throw on unhandled exception and rejection
+// TODO: Why don't these get caught by Vitest? They used to...
+process.on("uncaughtException", err => {
+  throw err;
+});
+process.on("unhandledRejection", reason => {
+  throw reason;
+});

--- a/test/setup/vitest.setup.ts
+++ b/test/setup/vitest.setup.ts
@@ -134,12 +134,3 @@ afterEach(context => {
 });
 
 // #endregion Hooks
-
-// throw on unhandled exception and rejection
-// TODO: Why don't these get caught by Vitest? They used to...
-process.on("uncaughtException", err => {
-  throw err;
-});
-process.on("unhandledRejection", reason => {
-  throw reason;
-});

--- a/test/tests/phases/form-change-phase.test.ts
+++ b/test/tests/phases/form-change-phase.test.ts
@@ -41,7 +41,7 @@ describe("Form Change Phase", () => {
     const zacian = game.field.getPlayerPokemon();
     expect(zacian.getFormKey()).toBe("hero-of-many-battles");
     expect(zacian.getTypes()).toStrictEqual([PokemonType.FAIRY]);
-    expect(zacian.calculateBaseStats()).toStrictEqual([92, 120, 115, 80, 115, 138]);
+    expect(zacian["calculateBaseStats"]()).toStrictEqual([92, 120, 115, 80, 115, 138]);
 
     // Give Zacian a Rusted Sword
     const rustedSwordType = generateModifierType(modifierTypes.RARE_FORM_CHANGE_ITEM)!;
@@ -55,7 +55,7 @@ describe("Form Change Phase", () => {
     expect(game.phaseInterceptor.phaseLog.includes("FormChangePhase")).toBe(true);
     expect(zacian.getFormKey()).toBe("crowned");
     expect(zacian.getTypes()).toStrictEqual([PokemonType.FAIRY, PokemonType.STEEL]);
-    expect(zacian.calculateBaseStats()).toStrictEqual([92, 150, 115, 80, 115, 148]);
+    expect(zacian["calculateBaseStats"]()).toStrictEqual([92, 150, 115, 80, 115, 148]);
   });
 
   it("should end Terastallization when the Pokemon undergoes a Primal Reversion", async () => {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
I noticed the `calculateStats` function could be broken up a bit.
Then, noticed a function it called could have a parameter type tightened.
Then, I noticed the docs for some stuff in `#enums/stats` were grammatically incorrect ("stat the values" instead of "the stat values").
Then, I noticed a function DayKev mentioned in Discord created an extra lambda unnecessarily.

## What are the changes from a developer perspective?
Fixed the above miscellaneous issues.
## Screenshots/Videos
N/A
## How to test the changes?
N/A

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
