### PR TITLE
misc: remove unused parameter from `toDmgValue`

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2220,6 +2220,13 @@ export class RecoilAttr extends MoveEffectAttr {
       return false;
     }
 
+    // don't do anything if a damaging recoil move didn't deal damage.
+    // Whether this goes before or after the ability check is unobservable in mainline for lack of a flyout,
+    // but putting it first avoids giving information to the enemy trainer AI that's ambiguous.
+    if (!this.useHp && user.turnData.totalDamageDealt === 0) {
+      return false;
+    }
+
     const cancelled = new BooleanHolder(false);
     if (!this.unblockable) {
       const abAttrParams: AbAttrParamsWithCancel = { pokemon: user, cancelled };
@@ -2239,16 +2246,7 @@ export class RecoilAttr extends MoveEffectAttr {
       return false;
     }
 
-    const damageValue = (this.useHp ? user.getMaxHp() : user.turnData.totalDamageDealt) * this.damageRatio;
-    const minValue = user.turnData.totalDamageDealt ? 1 : 0;
-    const recoilDamage = toDmgValue(damageValue, minValue);
-    if (!recoilDamage) {
-      return false;
-    }
-
-    if (cancelled.value) {
-      return false;
-    }
+    const recoilDamage = toDmgValue(this.useHp ? user.getMaxHp() : user.turnData.totalDamageDealt * this.damageRatio);
 
     user.damageAndUpdate(recoilDamage, { result: HitResult.INDIRECT, ignoreSegments: true });
     globalScene.phaseManager.queueMessage(

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2246,7 +2246,7 @@ export class RecoilAttr extends MoveEffectAttr {
       return false;
     }
 
-    const recoilDamage = toDmgValue(this.useHp ? user.getMaxHp() : user.turnData.totalDamageDealt * this.damageRatio);
+    const recoilDamage = toDmgValue((this.useHp ? user.getMaxHp() : user.turnData.totalDamageDealt) * this.damageRatio);
 
     user.damageAndUpdate(recoilDamage, { result: HitResult.INDIRECT, ignoreSegments: true });
     globalScene.phaseManager.queueMessage(

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -363,12 +363,11 @@ export function truncateString(str: string, maxLength = 10) {
  * The actual damage applied to a Pokémon's HP must be an integer.
  * This function helps in ensuring that by flooring the float value and enforcing a minimum damage value.
  *
- * @param value - The float value to convert.
- * @param minValue - The minimum integer value to return. Defaults to 1.
+ * @param value - The value to round
  * @returns The converted value as an integer.
  */
-export function toDmgValue(value: number, minValue = 1) {
-  return Math.max(Math.floor(value), minValue);
+export function toDmgValue(value: number): number {
+  return Math.max(Math.floor(value), 1);
 }
 
 /**


### PR DESCRIPTION

## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
We shouldn't have extra parameters to functions that do basically nothing.

I noticed the recoil code was the only thing passing a custom floor to `toDmgValue`, and was instantly early returning if it became 0.
This was actually incorrect (or would be, were our implementations of Mind Blown and Steel Beam not bugged to deal no recoil on miss). Shedinja SHOULD be able to KO itself with 50% of its 1 max HP worth in of recoil damage (clamped to 1, of course); passing a floor of `0` would cause it to early-return the same as an ineffective damage-based recoil move.

> [!NOTE]
> This is not a bug now, but would become a bug later.
> (It's jank code either way.)

## What are the changes from a developer perspective?
Removed the 2nd parameter to `toDmgValue` in the recoil code, and added a check to early-return if the recoil move didn't deal any damage (for damage-based recoil moves).

## Screenshots/Videos
N/A
## How to test the changes?
Run recoil move tests and confirm they still pass

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
