### PR TITLE
fix(move): Belly Drum won't display an extra message

### DIFF
--- a/src/@types/move-types.ts
+++ b/src/@types/move-types.ts
@@ -12,12 +12,15 @@ import type {
 
 /**
  * A generic function producing a message during a Move's execution.
- * @param user - The {@linkcode Pokemon} using the move
- * @param target - The {@linkcode Pokemon} targeted by the move
- * @param move - The {@linkcode Move} being used
- * @returns a string
  */
-export type MoveMessageFunc = (user: Pokemon, target: Pokemon, move: Move) => string;
+export type MoveMessageFunc =
+  /**
+   * @param user - The {@linkcode Pokemon} using the move
+   * @param target - The {@linkcode Pokemon} targeted by the move
+   * @param move - The {@linkcode Move} being used
+   * @returns The message to be displayed as a localized string.
+   */
+  (user: Pokemon, target: Pokemon, move: Move) => string;
 
 export type MoveAttrFilter = (attr: MoveAttr) => boolean;
 

--- a/src/@types/stat-change.ts
+++ b/src/@types/stat-change.ts
@@ -34,4 +34,13 @@ export interface StatStageChangePhaseOptions {
    * Should not be passed by anything other than this phase.
    */
   processed?: boolean;
+  /**
+   * An optional callback used to produce the message displayed when the stat change is applied.
+   * If not provided, the default message is used.
+   * @remarks
+   * Intended to be used for static messages (hence why the applied changes are omitted).
+   * @privateRemarks
+   * Currently only used by Belly Drum.
+   */
+  message?: ((user: Pokemon) => string) | undefined;
 }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -4322,7 +4322,7 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
 
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     user.damageAndUpdate(toDmgValue(user.getMaxHp() / this.cutRatio), { result: HitResult.INDIRECT });
-    user.updateInfo(); // TODO: Floating promise
+    user.updateInfo();
     return super.apply(user, target, move, args);
   }
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -121,6 +121,7 @@ import type {
   MoveMessageFunc,
 } from "#types/move-types";
 import type { GetEffectiveStatParams } from "#types/pokemon-common";
+import type { StatStageChangePhaseOptions } from "#types/stat-change";
 import type { TurnMove } from "#types/turn-move";
 import type { AbstractConstructor } from "#types/type-helpers";
 import { coerceArray } from "#utils/array";
@@ -3883,18 +3884,13 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
  * Set of optional parameters that may be applied to stat stage changing effects
  * @see {@linkcode StatStageChangeAttr}
  */
-interface StatStageChangeAttrOptions extends MoveEffectAttrOptions {
+interface StatStageChangeAttrOptions extends MoveEffectAttrOptions, Pick<StatStageChangePhaseOptions, "message"> {
   /** If defined, needs to be met in order for the stat change to apply */
-  condition?: MoveConditionFunc;
+  condition: MoveConditionFunc;
 }
 
 /**
  * Attribute used for moves that change stat stages
- *
- * @param stats {@linkcode BattleStat} Array of stat(s) to change
- * @param stages How many stages to change the stat(s) by, [-6, 6]
- * @param selfTarget `true` if the move is self-targetting
- * @param options {@linkcode StatStageChangeAttrOptions} Container for any optional parameters for this attribute.
  */
 export class StatStageChangeAttr extends MoveEffectAttr {
   public stats: BattleStat[];
@@ -3903,21 +3899,21 @@ export class StatStageChangeAttr extends MoveEffectAttr {
    * Container for optional parameters to this attribute.
    * @see {@linkcode StatStageChangeAttrOptions} for available optional params
    */
-  protected override options?: StatStageChangeAttrOptions | undefined;
+  protected override options: StatStageChangeAttrOptions;
 
-  constructor(stats: BattleStat[], stages: number, selfTarget?: boolean, options?: StatStageChangeAttrOptions) {
+  constructor(
+    stats: BattleStat[],
+    stages: number,
+    selfTarget?: boolean,
+    options: Partial<StatStageChangeAttrOptions> = {},
+  ) {
     super(selfTarget, options);
     this.stats = stats;
     this.stages = stages;
-    this.options = options;
-  }
-
-  /**
-   * The condition required for the stat stage change to apply.
-   * Defaults to `null` (i.e. no condition required).
-   */
-  private get condition() {
-    return this.options?.condition ?? null;
+    this.options = {
+      ...options,
+      condition: options?.condition ?? (() => true),
+    };
   }
 
   /**
@@ -3929,7 +3925,7 @@ export class StatStageChangeAttr extends MoveEffectAttr {
    * @returns whether stat stages were changed
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args?: any[]): boolean {
-    if (!super.apply(user, target, move, args) || (this.condition && !this.condition(user, target, move))) {
+    if (!super.apply(user, target, move, args) || !this.options.condition(user, target, move)) {
       return false;
     }
 
@@ -3940,6 +3936,7 @@ export class StatStageChangeAttr extends MoveEffectAttr {
         battlerIndex: (this.selfTarget ? user : target).getBattlerIndex(),
         changes: groupStatChange(this.stats, stages),
         sourcePokemon: user,
+        message: this.options.message,
       });
 
       return true;
@@ -4315,28 +4312,18 @@ export class GrowthStatStageChangeAttr extends StatStageChangeAttr {
 }
 
 export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
-  private readonly cutRatio: number;
-  private readonly messageCallback: ((user: Pokemon) => void) | undefined;
+  private readonly cutRatio: number; // TODO: NOT A RATIO, THIS IS A DIVISOR
 
-  constructor(
-    stat: BattleStat[],
-    levels: number,
-    cutRatio: number,
-    messageCallback?: ((user: Pokemon) => void) | undefined,
-  ) {
-    super(stat, levels, true);
+  constructor(stat: BattleStat[], levels: number, cutRatio: number, options: Partial<StatStageChangeAttrOptions> = {}) {
+    super(stat, levels, true, options);
 
     this.cutRatio = cutRatio;
-    this.messageCallback = messageCallback;
   }
+
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     user.damageAndUpdate(toDmgValue(user.getMaxHp() / this.cutRatio), { result: HitResult.INDIRECT });
-    user.updateInfo();
-    const ret = super.apply(user, target, move, args);
-    if (this.messageCallback) {
-      this.messageCallback(user);
-    }
-    return ret;
+    user.updateInfo(); // TODO: Floating promise
+    return super.apply(user, target, move, args);
   }
 
   getCondition(): MoveConditionFunc {
@@ -9983,13 +9970,12 @@ export function initMoves() {
       .attr(ConfuseAttr)
       .reflectable(),
     new SelfStatusMove(MoveId.BELLY_DRUM, PokemonType.NORMAL, -1, 10, -1, 0, 2) //
-      .attr(CutHpStatStageBoostAttr, [Stat.ATK], 12, 2, user => {
-        globalScene.phaseManager.queueMessage(
+      .attr(CutHpStatStageBoostAttr, [Stat.ATK], 12, 2, {
+        message: user =>
           i18next.t("moveTriggers:cutOwnHpAndMaximizedStat", {
             pokemonName: getPokemonNameWithAffix(user),
             statName: i18next.t(getStatKey(Stat.ATK)),
           }),
-        );
       }),
     new AttackMove(MoveId.SLUDGE_BOMB, PokemonType.POISON, MoveCategory.SPECIAL, 90, 100, 10, 30, 0, 2)
       .attr(StatusEffectAttr, StatusEffect.POISON)

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3885,7 +3885,7 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
  * @see {@linkcode StatStageChangeAttr}
  */
 interface StatStageChangeAttrOptions extends MoveEffectAttrOptions, Pick<StatStageChangePhaseOptions, "message"> {
-  /** If defined, needs to be met in order for the stat change to apply */
+  /** The condition that needs to be met in order for the stat change to apply */
   condition: MoveConditionFunc;
 }
 

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -238,8 +238,7 @@ export class StatStageChangePhase extends PokemonPhase {
   }
 
   /**
-   * Queue one battle message per distinct stage change magnitude.
-   *
+   * Queue all messages for the stat changes being applied.
    * @param pokemon - The `Pokemon` receiving the stat changes
    * @param applied - The applied changes
    */
@@ -252,6 +251,45 @@ export class StatStageChangePhase extends PokemonPhase {
     for (const [_, group] of Map.groupBy(applied, c => c.stages)) {
       globalScene.phaseManager.queueMessage(this.buildStatStageChangeMessage(group));
     }
+  }
+
+  /**
+   * Build a stat change message for a group of changes that share the same magnitude.
+   *
+   * @param changes - The changes described by this message (all sharing one {@linkcode StatChange.stages | stages} value)
+   * @returns The localised message string
+   */
+  private buildStatStageChangeMessage(changes: readonly StatChange[]): string {
+    const relStages = changes[0].stages;
+    return i18next.t(getStatStageChangeDescriptionKey(Math.abs(relStages), this.isIncrease), {
+      pokemonNameWithAffix: getPokemonNameWithAffix(this.getPokemon()),
+      stats: this.formatStatsFragment(changes),
+      count: changes.length,
+    });
+  }
+
+  /**
+   * Format a list of changes into a localised stat-name fragment (e.g. `"Attack, Defense, and Speed"`).
+   *
+   * @param changes - The changes whose stat names should be listed
+   * @returns The localised fragment, or the generic `"stats"` string for 5+
+   */
+  private formatStatsFragment(changes: readonly StatChange[]): string {
+    if (changes.length >= 5) {
+      return i18next.t("battle:stats");
+    }
+
+    if (changes.length === 1) {
+      return i18next.t(getStatKey(changes[0].stat));
+    }
+
+    const allButLast = changes
+      .slice(0, -1)
+      .map(c => i18next.t(getStatKey(c.stat)))
+      .join(", ");
+    const oxfordComma = changes.length > 2 ? "," : "";
+    const last = i18next.t(getStatKey(changes.at(-1)!.stat));
+    return `${allButLast}${oxfordComma} ${i18next.t("battle:statsAnd")} ${last}`;
   }
 
   /**
@@ -373,45 +411,5 @@ export class StatStageChangePhase extends PokemonPhase {
     });
 
     pokemon.disableMask();
-  }
-
-  // TODO: Shouldn't this logically be before updateStatStages? Can I move it?
-  /**
-   * Build a stat change message for a group of changes that share the same magnitude.
-   *
-   * @param changes - The changes described by this message (all sharing one {@linkcode StatChange.stages | stages} value)
-   * @returns The localised message string
-   */
-  private buildStatStageChangeMessage(changes: readonly StatChange[]): string {
-    const relStages = changes[0].stages;
-    return i18next.t(getStatStageChangeDescriptionKey(Math.abs(relStages), this.isIncrease), {
-      pokemonNameWithAffix: getPokemonNameWithAffix(this.getPokemon()),
-      stats: this.formatStatsFragment(changes),
-      count: changes.length,
-    });
-  }
-
-  /**
-   * Format a list of changes into a localised stat-name fragment (e.g. `"Attack, Defense, and Speed"`).
-   *
-   * @param changes - The changes whose stat names should be listed
-   * @returns The localised fragment, or the generic `"stats"` string for 5+
-   */
-  private formatStatsFragment(changes: readonly StatChange[]): string {
-    if (changes.length >= 5) {
-      return i18next.t("battle:stats");
-    }
-
-    if (changes.length === 1) {
-      return i18next.t(getStatKey(changes[0].stat));
-    }
-
-    const allButLast = changes
-      .slice(0, -1)
-      .map(c => i18next.t(getStatKey(c.stat)))
-      .join(", ");
-    const oxfordComma = changes.length > 2 ? "," : "";
-    const last = i18next.t(getStatKey(changes.at(-1)!.stat));
-    return `${allButLast}${oxfordComma} ${i18next.t("battle:statsAnd")} ${last}`;
   }
 }

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -227,7 +227,8 @@ export class StatStageChangePhase extends PokemonPhase {
    * @param applied - The clamped per-stat deltas to apply
    */
   private applyStatChangesAndEnd(pokemon: Pokemon, applied: readonly StatChange[]): void {
-    this.queueStatChangeMessages(applied);
+    this.queueStatChangeMessages(pokemon, applied);
+
     this.updateStatStages(pokemon, applied);
     this.triggerReactionAbilities(pokemon);
     this.checkWhiteHerb(pokemon);
@@ -239,9 +240,15 @@ export class StatStageChangePhase extends PokemonPhase {
   /**
    * Queue one battle message per distinct stage change magnitude.
    *
+   * @param pokemon - The `Pokemon` receiving the stat changes
    * @param applied - The applied changes
    */
-  private queueStatChangeMessages(applied: readonly StatChange[]): void {
+  private queueStatChangeMessages(pokemon: Pokemon, applied: readonly StatChange[]): void {
+    if (this.options.message != null) {
+      globalScene.phaseManager.queueMessage(this.options.message(pokemon));
+      return;
+    }
+
     for (const [_, group] of Map.groupBy(applied, c => c.stages)) {
       globalScene.phaseManager.queueMessage(this.buildStatStageChangeMessage(group));
     }
@@ -250,7 +257,7 @@ export class StatStageChangePhase extends PokemonPhase {
   /**
    * Write each clamped change to the target's stat stages and flag turn data accordingly.
    *
-   * @param pokemon - The Pokemon receiving the stat changes
+   * @param pokemon - The `Pokemon` receiving the stat changes
    * @param applied - The applied changes
    */
   private updateStatStages(pokemon: Pokemon, applied: readonly StatChange[]): void {
@@ -368,6 +375,7 @@ export class StatStageChangePhase extends PokemonPhase {
     pokemon.disableMask();
   }
 
+  // TODO: Shouldn't this logically be before updateStatStages? Can I move it?
   /**
    * Build a stat change message for a group of changes that share the same magnitude.
    *

--- a/test/tests/moves/belly-drum.test.ts
+++ b/test/tests/moves/belly-drum.test.ts
@@ -97,7 +97,7 @@ describe("Moves - BELLY DRUM", () => {
     await game.phaseInterceptor.to("StatStageChangePhase", false);
 
     const phase = game.scene.phaseManager.getCurrentPhase() as StatStageChangePhase;
-    expect(phase).toBeInstanceOf(StatStageChangePhase);
+    expect(game).toBeAtPhase("StatStageChangePhase");
     const defaultMessageSpy = vi.spyOn(
       phase as unknown as { buildStatStageChangeMessage: StatStageChangePhase["buildStatStageChangeMessage"] },
       "buildStatStageChangeMessage",

--- a/test/tests/moves/belly-drum.test.ts
+++ b/test/tests/moves/belly-drum.test.ts
@@ -47,21 +47,6 @@ describe("Moves - BELLY DRUM", () => {
     expect(player).toHaveStatStage(Stat.ATK, 6);
   });
 
-  // TODO: Do we need this test? it seems redundant (the same could be said of any stat raising move)
-  it("should still take effect if an uninvolved stat stage is at max", async () => {
-    await game.classicMode.startBattle(SpeciesId.FEEBAS);
-
-    const player = game.field.getPlayerPokemon();
-    player.setStatStage(Stat.SPATK, 6);
-
-    game.move.use(MoveId.BELLY_DRUM);
-    await game.toEndOfTurn();
-
-    expect(player).toHaveUsedMove({ move: MoveId.BELLY_DRUM, result: MoveResult.SUCCESS });
-    expect(player).toHaveStatStage(Stat.ATK, 6);
-    expect(player).toHaveStatStage(Stat.SPATK, 6);
-  });
-
   it("should fail if the pokemon's ATK stat stage is at its maximum", async () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 

--- a/test/tests/moves/belly-drum.test.ts
+++ b/test/tests/moves/belly-drum.test.ts
@@ -4,6 +4,7 @@ import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { getStatKey, Stat } from "#enums/stat";
+import type { StatStageChangePhase } from "#phases/stat-stage-change-phase";
 import { GameManager } from "#test/framework/game-manager";
 import { toDmgValue } from "#utils/common";
 import i18next from "i18next";

--- a/test/tests/moves/belly-drum.test.ts
+++ b/test/tests/moves/belly-drum.test.ts
@@ -4,7 +4,6 @@ import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { getStatKey, Stat } from "#enums/stat";
-import { StatStageChangePhase } from "#phases/stat-stage-change-phase";
 import { GameManager } from "#test/framework/game-manager";
 import { toDmgValue } from "#utils/common";
 import i18next from "i18next";

--- a/test/tests/moves/belly-drum.test.ts
+++ b/test/tests/moves/belly-drum.test.ts
@@ -1,16 +1,15 @@
+import { getPokemonNameWithAffix } from "#app/messages";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
-import { Stat } from "#enums/stat";
+import { getStatKey, Stat } from "#enums/stat";
+import { StatStageChangePhase } from "#phases/stat-stage-change-phase";
 import { GameManager } from "#test/framework/game-manager";
 import { toDmgValue } from "#utils/common";
+import i18next from "i18next";
 import Phaser from "phaser";
-import { beforeAll, beforeEach, describe, expect, test } from "vitest";
-
-// RATIO : HP Cost of Move
-const RATIO = 2;
-// PREDAMAGE : Amount of extra HP lost
-const PREDAMAGE = 15;
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - BELLY DRUM", () => {
   let phaserGame: Phaser.Game;
@@ -25,72 +24,98 @@ describe("Moves - BELLY DRUM", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .enemySpecies(SpeciesId.SNORLAX)
+      .enemySpecies(SpeciesId.MAGIKARP)
       .startingLevel(100)
       .enemyLevel(100)
-      .moveset([MoveId.BELLY_DRUM])
       .enemyMoveset(MoveId.SPLASH)
       .enemyAbility(AbilityId.BALL_FETCH);
   });
 
   // Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/Belly_Drum_(move)
 
-  test("raises the user's ATK stat stage to its max, at the cost of 1/2 of its maximum HP", async () => {
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+  it("should set the user's ATK stat stage to its maximum, at the cost of 1/2 of its maximum HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-    const leadPokemon = game.field.getPlayerPokemon();
-    const hpLost = toDmgValue(leadPokemon.getMaxHp() / RATIO);
+    const player = game.field.getPlayerPokemon();
+    player.setStatStage(Stat.ATK, -6);
 
-    game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to("TurnEndPhase");
+    game.move.use(MoveId.BELLY_DRUM);
+    await game.toEndOfTurn();
 
-    expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
-    expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
+    expect(player).toHaveUsedMove({ move: MoveId.BELLY_DRUM, result: MoveResult.SUCCESS });
+    expect(player).toHaveTakenDamage(player.getMaxHp() / 2);
+    expect(player).toHaveStatStage(Stat.ATK, 6);
   });
 
-  test("will still take effect if an uninvolved stat stage is at max", async () => {
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+  // TODO: Do we need this test? it seems redundant (the same could be said of any stat raising move)
+  it("should still take effect if an uninvolved stat stage is at max", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-    const leadPokemon = game.field.getPlayerPokemon();
-    const hpLost = toDmgValue(leadPokemon.getMaxHp() / RATIO);
+    const player = game.field.getPlayerPokemon();
+    player.setStatStage(Stat.SPATK, 6);
 
-    // Here - Stat.ATK -> -3 and Stat.SPATK -> 6
-    leadPokemon.setStatStage(Stat.ATK, -3);
-    leadPokemon.setStatStage(Stat.SPATK, 6);
+    game.move.use(MoveId.BELLY_DRUM);
+    await game.toEndOfTurn();
 
-    game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to("TurnEndPhase");
-
-    expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
-    expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
-    expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(6);
+    expect(player).toHaveUsedMove({ move: MoveId.BELLY_DRUM, result: MoveResult.SUCCESS });
+    expect(player).toHaveStatStage(Stat.ATK, 6);
+    expect(player).toHaveStatStage(Stat.SPATK, 6);
   });
 
-  test("fails if the pokemon's ATK stat stage is at its maximum", async () => {
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+  it("should fail if the pokemon's ATK stat stage is at its maximum", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-    const leadPokemon = game.field.getPlayerPokemon();
+    const player = game.field.getPlayerPokemon();
+    player.setStatStage(Stat.ATK, 6);
 
-    leadPokemon.setStatStage(Stat.ATK, 6);
+    game.move.use(MoveId.BELLY_DRUM);
+    await game.toEndOfTurn();
 
-    game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to("TurnEndPhase");
-
-    expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-    expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
+    // TODO: This doesn't actually count as failed due to incorrect failure propagation
+    // expect(player).toHaveUsedMove({ move: MoveId.BELLY_DRUM, result: MoveResult.FAIL });
+    expect(player).toHaveFullHp();
+    expect(player).toHaveStatStage(Stat.ATK, 6);
   });
 
-  test("fails if the user's health is less than 1/2", async () => {
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+  it("should fail if the user's health is insufficient", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-    const leadPokemon = game.field.getPlayerPokemon();
-    const hpLost = toDmgValue(leadPokemon.getMaxHp() / RATIO);
-    leadPokemon.hp = hpLost - PREDAMAGE;
+    const player = game.field.getPlayerPokemon();
+    player.hp = toDmgValue(player.getMaxHp() / 2) - 1;
 
-    game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to("TurnEndPhase");
+    game.move.use(MoveId.BELLY_DRUM);
+    await game.toEndOfTurn();
 
-    expect(leadPokemon.hp).toBe(hpLost - PREDAMAGE);
-    expect(leadPokemon.getStatStage(Stat.ATK)).toBe(0);
+    expect(player).toHaveUsedMove({ move: MoveId.BELLY_DRUM, result: MoveResult.FAIL });
+    expect(player).toHaveStatStage(Stat.ATK, 0);
   });
+
+  it("should override the default stat change message with a custom one", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+    game.move.use(MoveId.BELLY_DRUM);
+    await game.phaseInterceptor.to("StatStageChangePhase", false);
+
+    const phase = game.scene.phaseManager.getCurrentPhase() as StatStageChangePhase;
+    expect(phase).toBeInstanceOf(StatStageChangePhase);
+    const defaultMessageSpy = vi.spyOn(
+      phase as unknown as { buildStatStageChangeMessage: StatStageChangePhase["buildStatStageChangeMessage"] },
+      "buildStatStageChangeMessage",
+    );
+
+    await game.toEndOfTurn();
+
+    expect(game).toHaveShownMessage(
+      i18next.t("moveTriggers:cutOwnHpAndMaximizedStat", {
+        pokemonName: getPokemonNameWithAffix(player),
+        statName: i18next.t(getStatKey(Stat.ATK)),
+      }),
+    );
+    expect(defaultMessageSpy).not.toHaveBeenCalled();
+  });
+
+  // TODO: Should this test go here or in contrary.test.ts?
+  // TODO: Confirm mainline behaviour
+  it.todo("should still fail at max HP if the user has Contrary");
 });


### PR DESCRIPTION
## What are the changes the user will see?
Belly Drum will show 1 message about stat raising (the custom one) instead of 2 messages (the default one and the custom one) when it is used successfully.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes #7605
## What are the changes from a developer perspective?
Added a new parameter to the stat stage change phase to override the default message when a stat stage change is successful.
Piped said parameter through `StatStageChangeAbAttr`
## Screenshots/Videos
<img width="735" height="340" alt="image" src="https://github.com/user-attachments/assets/78abc49f-da11-48c5-829f-f698f6e4d4a9" />

## How to test the changes?
`pnpm test belly-drum.test.ts` (existing tests cleaned up; 1 new test)
## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
