### PR TITLE
fix(ui): fix double battle info box render order after switch-ins

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -156,7 +156,7 @@ import type { StarterDataEntry, StarterMoveset } from "#types/save-data";
 import type { StatChange } from "#types/stat-change";
 import type { TurnMove } from "#types/turn-move";
 import type { AbstractConstructor } from "#types/type-helpers";
-import { BattleInfo } from "#ui/battle-info";
+import type { BattleInfo } from "#ui/battle-info";
 import { EnemyBattleInfo } from "#ui/enemy-battle-info";
 import type { PartyOption } from "#ui/party-ui-handler";
 import { PartyUiHandler } from "#ui/party-ui-handler";
@@ -3256,15 +3256,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /** Show this Pokémon's info panel */
   showInfo(): void {
     if (!this.battleInfo.visible) {
-      const otherBattleInfo = globalScene.fieldUI
-        .getAll()
-        .slice(0, 4)
-        .find(ui => ui instanceof BattleInfo && (ui as BattleInfo) instanceof PlayerBattleInfo === this.isPlayer());
-      if (!otherBattleInfo || !this.getFieldIndex()) {
+      // In double battles, the 2nd field slot's info box must render above the 1st's so they stack correctly
+      const allyBattleInfo = this.getAlly()?.getBattleInfo();
+      if (!allyBattleInfo || !this.getFieldIndex()) {
         globalScene.fieldUI.sendToBack(this.battleInfo);
         globalScene.sendTextToBack(); // Push the top right text objects behind everything else
       } else {
-        globalScene.fieldUI.moveAbove(this.battleInfo, otherBattleInfo);
+        globalScene.fieldUI.moveAbove(this.battleInfo, allyBattleInfo);
       }
       this.battleInfo.setX(this.battleInfo.x + (this.isPlayer() ? 150 : this.isBoss() ? -198 : -150));
       this.battleInfo.setVisible(true);

--- a/test/mocks/mocks-container/mock-container.ts
+++ b/test/mocks/mocks-container/mock-container.ts
@@ -183,23 +183,45 @@ export class MockContainer implements MockGameObject {
     return this;
   }
 
-  sendToBack(): this {
-    // Sends this Game Object to the back of its parent's display list.\
+  sendToBack(child: MockGameObject): this {
+    // Sends the given child to the back of this Container's display list.
+    const index = this.list.indexOf(child);
+    if (index > 0) {
+      this.list.splice(index, 1);
+      this.list.unshift(child);
+    }
     return this;
   }
 
-  moveTo(_obj): this {
-    // Moves this Game Object to the given index in the list.\
+  moveTo(child: MockGameObject, index: number): this {
+    // Moves the given child to the given index in this Container's display list.
+    const currentIndex = this.list.indexOf(child);
+    if (currentIndex !== -1 && index >= 0 && index < this.list.length) {
+      this.list.splice(currentIndex, 1);
+      this.list.splice(index, 0, child);
+    }
     return this;
   }
 
-  moveAbove(_obj): this {
-    // Moves this Game Object to be above the given Game Object in the display list.
+  moveAbove(child: MockGameObject, other: MockGameObject): this {
+    // Moves the child to directly above the other child; no-op if already above it (matches Phaser)
+    const currentIndex = this.list.indexOf(child);
+    const baseIndex = this.list.indexOf(other);
+    if (child !== other && currentIndex !== -1 && baseIndex !== -1 && currentIndex < baseIndex) {
+      this.list.splice(currentIndex, 1);
+      this.list.splice(baseIndex, 0, child);
+    }
     return this;
   }
 
-  moveBelow(_obj): this {
-    // Moves this Game Object to be below the given Game Object in the display list.
+  moveBelow(child: MockGameObject, other: MockGameObject): this {
+    // Moves the child to directly below the other child; no-op if already below it (matches Phaser)
+    const currentIndex = this.list.indexOf(child);
+    const baseIndex = this.list.indexOf(other);
+    if (child !== other && currentIndex !== -1 && baseIndex !== -1 && currentIndex > baseIndex) {
+      this.list.splice(currentIndex, 1);
+      this.list.splice(baseIndex, 0, child);
+    }
     return this;
   }
 
@@ -208,8 +230,13 @@ export class MockContainer implements MockGameObject {
     return this;
   }
 
-  bringToTop(_obj): this {
-    // Brings this Game Object to the top of its parents display list.
+  bringToTop(child: MockGameObject): this {
+    // Brings the given child to the top of this Container's display list.
+    const index = this.list.indexOf(child);
+    if (index !== -1 && index < this.list.length - 1) {
+      this.list.splice(index, 1);
+      this.list.push(child);
+    }
     return this;
   }
 

--- a/test/tests/battle/double-battle.test.ts
+++ b/test/tests/battle/double-battle.test.ts
@@ -2,6 +2,7 @@ import { getGameMode } from "#app/game-mode";
 import { Status } from "#data/status-effect";
 import { AbilityId } from "#enums/ability-id";
 import { BattleType } from "#enums/battle-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { GameModes } from "#enums/game-modes";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -9,6 +10,7 @@ import { StatusEffect } from "#enums/status-effect";
 import { TrainerType } from "#enums/trainer-type";
 import { TrainerVariant } from "#enums/trainer-variant";
 import { UiMode } from "#enums/ui-mode";
+import type { Pokemon } from "#field/pokemon";
 import { GameManager } from "#test/framework/game-manager";
 import type { ModifierSelectUiHandler } from "#ui/modifier-select-ui-handler";
 import Phaser from "phaser";
@@ -158,5 +160,69 @@ describe("Double Battles", () => {
     await game.toEndOfTurn(false);
 
     expect(game.scene.phaseManager["phaseQueue"].findAll("BattleEndPhase")).toHaveLength(1);
+  });
+
+  describe("Info box render order", () => {
+    /** Position of the pokemon's info box in the field UI display list; higher renders on top */
+    const getInfoBoxIndex = (pokemon: Pokemon) => game.scene.fieldUI.getAll().indexOf(pokemon.getBattleInfo());
+
+    /**
+     * Clear the current wave and start the next one.
+     * From the 2nd wave on, the enemy info boxes are shown after the player's remain on screen,
+     * which is the display list state that exposed the ordering bug.
+     */
+    async function toNextDoubleWave(): Promise<void> {
+      game.move.use(MoveId.SPLASH, BattlerIndex.PLAYER);
+      game.move.use(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+      await game.doKillOpponents();
+      await game.toNextWave();
+      expect(game.scene.getPlayerField()).toHaveLength(2);
+      expect(game.scene.getEnemyField()).toHaveLength(2);
+    }
+
+    beforeEach(() => {
+      game.override.battleStyle("double");
+    });
+
+    it("should render the 2nd field slot's info box above the 1st's", async () => {
+      await game.classicMode.startBattle(SpeciesId.BULBASAUR, SpeciesId.CHARIZARD);
+
+      const [bulbasaur, charizard] = game.scene.getPlayerField();
+      expect(getInfoBoxIndex(charizard)).toBeGreaterThan(getInfoBoxIndex(bulbasaur));
+
+      const [enemy1, enemy2] = game.scene.getEnemyField();
+      expect(getInfoBoxIndex(enemy2)).toBeGreaterThan(getInfoBoxIndex(enemy1));
+    });
+
+    it("should render a pokemon switched into the 2nd field slot above the 1st slot's info box", async () => {
+      await game.classicMode.startBattle(SpeciesId.BULBASAUR, SpeciesId.CHARIZARD, SpeciesId.SQUIRTLE);
+
+      const [bulbasaur, , squirtle] = game.scene.getPlayerParty();
+      await toNextDoubleWave();
+
+      // Bulbasaur / Squirtle // Charizard
+      game.move.use(MoveId.SPLASH, BattlerIndex.PLAYER);
+      game.doSwitchPokemon(2);
+      await game.toNextTurn();
+
+      expect(game.scene.getPlayerField()).toEqual([bulbasaur, squirtle]);
+      expect(getInfoBoxIndex(squirtle)).toBeGreaterThan(getInfoBoxIndex(bulbasaur));
+    });
+
+    it("should render a pokemon replacing a fainted 2nd field slot above the 1st slot's info box", async () => {
+      await game.classicMode.startBattle(SpeciesId.BULBASAUR, SpeciesId.CHARIZARD, SpeciesId.SQUIRTLE);
+
+      const [bulbasaur, charizard, squirtle] = game.scene.getPlayerParty();
+      await toNextDoubleWave();
+
+      game.move.use(MoveId.SPLASH, BattlerIndex.PLAYER);
+      game.move.use(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+      await game.killPokemon(charizard);
+      game.doSelectPartyPokemon(2);
+      await game.toNextTurn();
+
+      expect(game.scene.getPlayerField()).toEqual([bulbasaur, squirtle]);
+      expect(getInfoBoxIndex(squirtle)).toBeGreaterThan(getInfoBoxIndex(bulbasaur));
+    });
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

In double battles, a Pokémon sent into the second (lower) field slot after the first turn of a wave no longer has its info box drawn underneath the first slot's box. Previously the top box (and its stat-stage panel when holding the stats button) overlapped the bottom one.

<!-- ## Changelog cutoff -->

## Why am I making these changes?

`Pokemon.showInfo` decides the draw order of the two info boxes on one side of the field by looking for a sibling `BattleInfo` among only the first four children of `fieldUI`. Every time a slot-0 box is shown, `sendTextToBack` also pushes the score, money and wave text objects to the very front of that list. From wave 2 onward the enemy boxes are the most recently shown, so the first four children are the three text objects plus the slot-0 enemy box. A player Pokémon switched or sent in to slot 1 then finds no sibling, is sent to the back, and renders under the slot-0 box. The same applies to enemy replacements in trainer double battles.

## What are the changes from a developer perspective?

- `src/field/pokemon.ts`: `showInfo` now takes the sibling box directly from `this.getAlly()?.getBattleInfo()` instead of scanning `fieldUI.getAll().slice(0, 4)`. Slot 0 (or no ally) is still sent to the back; slot 1 is moved directly above the ally's box. The `BattleInfo` import becomes type-only.
- `test/mocks/mocks-container/mock-container.ts`: `sendToBack`, `bringToTop`, `moveAbove`, `moveBelow` and `moveTo` were no-op stubs. They now reorder `list` with the same semantics as Phaser's `Container` methods (`moveAbove`/`moveBelow` are no-ops when the child is already on the requested side), so tests can observe display order.
- `test/tests/battle/double-battle.test.ts`: new `Info box render order` block with three cases: initial order for both sides, a command switch into slot 1 on wave 2, and a faint replacement into slot 1 on wave 2. The latter two fail on `beta` without the fix.

## Screenshots/Videos

N/A (human to add if desired)

## How to test the changes?

`src/overrides.ts`:

```ts
BATTLE_STYLE_OVERRIDE: "double",
```

Start a classic run with three or more Pokémon, clear wave 1, then on wave 2 switch the lower Pokémon out (or let it faint and send in a replacement). Hold the stats button: the new lower box should draw over the upper box, not under it.

Automated: `pnpm test:silent test/tests/battle/double-battle.test.ts`

## Checklist

- [x] I'm using `beta` as my base branch
- [x] There is no overlap with another PR?
- [x] The PR title matches the requirements
- [x] Have I handled all issues or updates relating to this PR?
- [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I made sure that any UI change works for both UI themes (default and legacy)?
- [x] The changes have been verified by running `pnpm test:silent`, `pnpm biome`, and `pnpm typecheck`
- [ ] Have I tested the changes manually? (not yet, human to verify in game)
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
