### PR TITLE
refactor: Clean up `StatStageChangePhase` slightly and remove deep copy

### DIFF
--- a/src/@types/stat-change.ts
+++ b/src/@types/stat-change.ts
@@ -6,10 +6,7 @@ import type { PokemonPhase } from "#phases/pokemon-phase";
 import type { StatStageChangePhase } from "#phases/stat-stage-change-phase";
 
 /**
- * Interface representing a single stat stage change.
- * @privateRemarks
- * Marked as `readonly` to prevent accidental mutation of data.
- */
+/** Interface representing a single stat stage change. */
 export interface StatChange {
   /** The stat to change. */
   readonly stat: BattleStat;

--- a/src/@types/stat-change.ts
+++ b/src/@types/stat-change.ts
@@ -2,36 +2,66 @@ import type { BattlerIndex } from "#enums/battler-index";
 import type { BattleStat } from "#enums/stat";
 import type { StatChangeSource } from "#enums/stat-change-source";
 import type { Pokemon } from "#field/pokemon";
+import type { PokemonPhase } from "#phases/pokemon-phase";
+import type { StatStageChangePhase } from "#phases/stat-stage-change-phase";
 
 /**
- * Represents a single stat stage change. Readonly to avoid accidental changes.
+ * Interface representing a single stat stage change.
+ * @privateRemarks
+ * Marked as `readonly` to prevent accidental mutation of data.
  */
 export interface StatChange {
+  /** The stat to change. */
   readonly stat: BattleStat;
+  /** The number of stages to change the stat by. */
+  // TODO: The only reason we cannot make this `StatStage` is belly drum
   readonly stages: number;
 }
 
-export type StatStageChangeCallback = (target: Pokemon | null, changed: readonly StatChange[]) => void;
+export type StatStageChangeCallback = (target: Pokemon | null, changes: readonly StatChange[]) => void;
 
+/**
+ * Options type for {@linkcode StatStageChangePhase}.
+ * @privateRemarks
+ * Callers are free to re-use the same options between calls if desired,
+ * as the Phase shallow-clones all relevant fields.
+ */
 export interface StatStageChangePhaseOptions {
-  battlerIndex: BattlerIndex | number;
-  changes: readonly StatChange[];
-  /** The Pokemon who caused these stat changes (may be the same as the Pokemon this Phase is applied to). */
-  sourcePokemon: Pokemon | undefined;
-  /** If `true`, skip `StatStageChangeMultiplierAbAttr` */
-  ignoreAbilities?: boolean;
+  /**
+   * The {@linkcode BattlerIndex} of the `Pokemon` receiving the stat changes.
+   * Forwarded directly to {@linkcode PokemonPhase}'s constructor.
+   */
+  readonly battlerIndex: BattlerIndex | number;
+  /** The stat changes to be applied. */
+  // TODO: Enforce nonemptiness
+  readonly changes: readonly StatChange[];
+  /**
+   * The `Pokemon` who caused the stat changes, or `undefined` if the changes were caused by a non-Pokemon effect.
+   * @remarks
+   * May be the same as the `Pokemon` receiving the changes.
+   */
+  readonly sourcePokemon: Pokemon | undefined;
+  /**
+   * Whether to ignore abilities that could affect the stat changes being applied.
+   * @defaultValue `false`
+   */
+  readonly ignoreAbilities?: boolean;
   /**
    * A callback to invoke with the applied changes.
    * Used exclusively to allow Stockpile to track the stat stages actually applied.
    */
-  onChange?: StatStageChangeCallback;
-  /** The category of effect that produced this change, if relevant */
-  sourceEffectType?: StatChangeSource;
+  readonly onChange?: StatStageChangeCallback;
+  /**
+   * The category of effect that produced this change, if relevant.
+   * Used to enable or disable certain effects like Mirror Armor and Opportunist.
+   */
+  readonly sourceEffectType?: StatChangeSource;
   /**
    * When `true`, pre-processing (multipliers, protection checks, sign-splitting)
-   * is skipped because it was already performed by the phase that queued this one.
+   * will be skipped due to being already performed by the phase that queued this one.
+   * @defaultValue `false`
    * @remarks
-   * Should not be passed by anything other than this phase.
+   * Should not be passed by anything other than this Phase.
    */
-  processed?: boolean;
+  readonly processed?: boolean;
 }

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -350,8 +350,6 @@ export class StatStageChangePhase extends PokemonPhase {
    * @param pokemon - The Pokemon to check
    */
   private checkWhiteHerb(pokemon: Pokemon): void {
-    // TODO: Consider whether the item application would make more sense during the end of the move sequence;
-    // this seems a bit prone to breaking unintentionally
     const hasMoreStatPhases = globalScene.phaseManager.hasPhaseOfType(
       "StatStageChangePhase",
       p => p.battlerIndex === this.battlerIndex,

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -43,7 +43,6 @@ export class StatStageChangePhase extends PokemonPhase {
     super(options.battlerIndex);
 
     // Allow changes with 0 stages to be passed as no-ops
-    // TODO: Do we want to allow this? It's probably a mistake unless it's inside a `map` call or something...
     this.options = { ...options, changes: options.changes.filter(c => c.stages !== 0) };
     // TODO: Change this once `getPokemon`'s return type is fixed
     this.selfTarget = options.sourcePokemon != null && options.sourcePokemon === this.getPokemon();
@@ -199,9 +198,8 @@ export class StatStageChangePhase extends PokemonPhase {
    * split the negative changes into a follow-up {@linkcode StatStageChangePhase}.
    */
   private splitBySign(): void {
-    const { positive = [], negative = [] } = Object.groupBy(this.options.changes, c =>
-      c.stages > 0 ? "positive" : "negative",
-    );
+    const positive = this.options.changes.filter(c => c.stages >= 0);
+    const negative = this.options.changes.filter(c => c.stages < 0);
 
     if (positive.length === 0 || negative.length === 0) {
       return;
@@ -224,11 +222,7 @@ export class StatStageChangePhase extends PokemonPhase {
   private getAppliedChanges(pokemon: Pokemon): StatChange[] {
     return this.options.changes.map(({ stat, stages }) => {
       const current = pokemon.getStatStage(stat);
-      // type assertion is always safe (though TS cannot know it):
-      // - `delta` is always an integer since `current` and `stages` both are
-      // - If `stages > 0`, then `delta = min(stages, 6 - current) ∈ [0, 6]`
-      // - If `stages < 0`, then `delta = max(stages, -6 - current) ∈ [-6, 0]`
-      // - if `stages = 0`, then we would have filtered it out in the constructor
+      // this is always inside [-6, 6]
       const delta = Phaser.Math.Clamp(current + stages, -6, 6) - current;
       return { stat, stages: delta };
     });

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -4,9 +4,9 @@ import { globalScene } from "#app/global-scene";
 import { settings } from "#app/global-settings-manager";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { handleTutorial, Tutorial } from "#app/tutorial";
-import { OctolockTag } from "#data/battler-tags";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { type BattleStat, getStatKey, getStatStageChangeDescriptionKey, Stat } from "#enums/stat";
 import { StatChangeSource } from "#enums/stat-change-source";
 import type { Pokemon } from "#field/pokemon";
@@ -15,7 +15,6 @@ import { PokemonPhase } from "#phases/pokemon-phase";
 import type { ConditionalUserFieldProtectStatAbAttrParams, PreStatStageChangeAbAttrParams } from "#types/ability-types";
 import type { StatChange, StatStageChangePhaseOptions } from "#types/stat-change";
 import { playTween } from "#utils/anim-utils";
-import { deepCopy } from "#utils/data";
 import { ValueHolder } from "#utils/value-holder";
 import i18next from "i18next";
 import type { Writable } from "type-fest";
@@ -30,19 +29,24 @@ import type { Writable } from "type-fest";
 export class StatStageChangePhase extends PokemonPhase {
   public override readonly phaseName = "StatStageChangePhase";
 
-  private readonly options: StatStageChangePhaseOptions;
-  /** Whether the target caused its own stat changes for this phase */
+  /**
+   * The options passed in the constructor.
+   * Shallow-cloned to allow mutating the `changes` array without affecting the caller's reference.
+   */
+  private readonly options: Writable<StatStageChangePhaseOptions, "changes">;
+  /** Whether the target caused its own stat changes for this phase. */
   private readonly selfTarget: boolean;
-  /** Whether this phase represents a stat stage increase, set after splitting changes by sign */
+  /** Whether this phase represents a stat stage increase; set after splitting changes by sign. */
   private isIncrease = false;
 
   constructor(options: StatStageChangePhaseOptions) {
     super(options.battlerIndex);
 
-    this.options = { ...options };
+    // Allow changes with 0 stages to be passed as no-ops
+    // TODO: Do we want to allow this? It's probably a mistake unless it's inside a `map` call or something...
+    this.options = { ...options, changes: options.changes.filter(c => c.stages !== 0) };
     // TODO: Change this once `getPokemon`'s return type is fixed
     this.selfTarget = options.sourcePokemon != null && options.sourcePokemon === this.getPokemon();
-    this.options.changes = deepCopy(options.changes).filter(c => c.stages !== 0); // Allow changes with 0 stages to be passed as no-ops
   }
 
   // @ts-expect-error: TODO: the return type of `PokemonPhase#getPokemon` is wrong
@@ -68,6 +72,7 @@ export class StatStageChangePhase extends PokemonPhase {
       this.end();
       return;
     }
+
     this.isIncrease = this.options.changes.some(c => c.stages > 0);
 
     const applied = this.getAppliedChanges(pokemon);
@@ -93,9 +98,10 @@ export class StatStageChangePhase extends PokemonPhase {
     const multiplier = new ValueHolder(1);
     applyAbAttrs("StatStageChangeMultiplierAbAttr", { pokemon, numStages: multiplier });
 
-    for (const change of this.options.changes) {
-      (change as Writable<StatChange>).stages *= multiplier.value;
-    }
+    this.options.changes = this.options.changes.map(({ stat, stages }) => ({
+      stat,
+      stages: stages * multiplier.value,
+    }));
   }
 
   /**
@@ -105,12 +111,14 @@ export class StatStageChangePhase extends PokemonPhase {
    * @param pokemon - The Pokemon receiving the stat changes
    */
   private removeCancelledChanges(pokemon: Pokemon): void {
+    const { changes } = this.options;
     if (this.selfTarget) {
       return;
     }
+
     // NB: This currently hardcodes the fact that abilities and field effects can _only_ respond to stat decreases and not increases.
     // If any effects that can cancel stat stage increases are added, this check should be removed.
-    const negative = this.options.changes.filter(c => c.stages < 0);
+    const negative = changes.filter(c => c.stages < 0);
     if (negative.length === 0) {
       return;
     }
@@ -123,16 +131,16 @@ export class StatStageChangePhase extends PokemonPhase {
       pokemon.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY,
       false,
       pokemon,
-      this.options.changes,
+      changes,
       cancelledStats,
       opponent,
     );
 
-    if (cancelledStats.size < this.options.changes.length) {
+    if (cancelledStats.size < changes.length) {
       this.checkAbilityProtection(pokemon, opponent, negative, cancelledStats);
     }
 
-    this.options.changes = this.options.changes.filter(c => !cancelledStats.has(c.stat));
+    this.options.changes = changes.filter(c => !cancelledStats.has(c.stat));
   }
 
   /**
@@ -172,7 +180,7 @@ export class StatStageChangePhase extends PokemonPhase {
     if (
       opponentPokemon == null
       || this.options.sourceEffectType === StatChangeSource.MIRROR_ARMOR
-      || pokemon.findTag(t => t instanceof OctolockTag)
+      || pokemon.getTag(BattlerTagType.OCTOLOCK)
     ) {
       return;
     }
@@ -191,8 +199,9 @@ export class StatStageChangePhase extends PokemonPhase {
    * split the negative changes into a follow-up {@linkcode StatStageChangePhase}.
    */
   private splitBySign(): void {
-    const positive = this.options.changes.filter(c => c.stages >= 0);
-    const negative = this.options.changes.filter(c => c.stages < 0);
+    const { positive = [], negative = [] } = Object.groupBy(this.options.changes, c =>
+      c.stages > 0 ? "positive" : "negative",
+    );
 
     if (positive.length === 0 || negative.length === 0) {
       return;
@@ -215,8 +224,13 @@ export class StatStageChangePhase extends PokemonPhase {
   private getAppliedChanges(pokemon: Pokemon): StatChange[] {
     return this.options.changes.map(({ stat, stages }) => {
       const current = pokemon.getStatStage(stat);
-      const clamped = Phaser.Math.Clamp(current + stages, -6, 6);
-      return { stat, stages: clamped - current };
+      // type assertion is always safe (though TS cannot know it):
+      // - `delta` is always an integer since `current` and `stages` both are
+      // - If `stages > 0`, then `delta = min(stages, 6 - current) ∈ [0, 6]`
+      // - If `stages < 0`, then `delta = max(stages, -6 - current) ∈ [-6, 0]`
+      // - if `stages = 0`, then we would have filtered it out in the constructor
+      const delta = Phaser.Math.Clamp(current + stages, -6, 6) - current;
+      return { stat, stages: delta };
     });
   }
 
@@ -233,7 +247,7 @@ export class StatStageChangePhase extends PokemonPhase {
     this.checkWhiteHerb(pokemon);
 
     pokemon.updateInfo();
-    handleTutorial(Tutorial.STAT_CHANGE).then(() => super.end());
+    handleTutorial(Tutorial.STAT_CHANGE).then(() => this.end());
   }
 
   /**
@@ -277,19 +291,17 @@ export class StatStageChangePhase extends PokemonPhase {
    * mainline.  For example, Defiant will proc as a single +4 when two stats
    * are dropped instead of twice +2, which would be a real difference for
    * something like Mirror Herb (copying +4 instead of a single +2) but is
-   * otherwise not significant beyond faster animation.
+   * otherwise not significant beyond faster animations.
    */
   private triggerReactionAbilities(pokemon: Pokemon): void {
-    if (
-      this.options.sourceEffectType !== StatChangeSource.OPPORTUNIST
-      && this.options.changes.some(c => c.stages > 0)
-    ) {
+    const { changes, sourceEffectType } = this.options;
+    if (sourceEffectType !== StatChangeSource.OPPORTUNIST && changes.some(c => c.stages > 0)) {
       for (const opponent of pokemon.getOpponentsGenerator()) {
-        applyAbAttrs("StatStageChangeCopyAbAttr", { pokemon: opponent, changes: this.options.changes });
+        applyAbAttrs("StatStageChangeCopyAbAttr", { pokemon: opponent, changes });
       }
     }
 
-    applyAbAttrs("PostStatStageChangeAbAttr", { pokemon, changes: this.options.changes, selfTarget: this.selfTarget });
+    applyAbAttrs("PostStatStageChangeAbAttr", { pokemon, changes, selfTarget: this.selfTarget });
   }
 
   /**
@@ -299,6 +311,8 @@ export class StatStageChangePhase extends PokemonPhase {
    * @param pokemon - The Pokemon to check
    */
   private checkWhiteHerb(pokemon: Pokemon): void {
+    // TODO: Consider whether the item application would make more sense during the end of the move sequence;
+    // this seems a bit prone to breaking unintentionally
     const hasMoreStatPhases = globalScene.phaseManager.hasPhaseOfType(
       "StatStageChangePhase",
       p => p.battlerIndex === this.battlerIndex,
@@ -337,8 +351,8 @@ export class StatStageChangePhase extends PokemonPhase {
 
     // On increase, show the red sprite located at ATK; on decrease, the blue sprite at SPD
     const spriteColor = this.isIncrease ? Stat[Stat.ATK].toLowerCase() : Stat[Stat.SPD].toLowerCase();
-    const statSprite = globalScene.add.tileSprite(tileX, tileY, tileWidth, tileHeight, "battle_stats", spriteColor);
-    statSprite
+    const statSprite = globalScene.add
+      .tileSprite(tileX, tileY, tileWidth, tileHeight, "battle_stats", spriteColor)
       .setPipeline(globalScene.fieldSpritePipeline)
       .setAlpha(0)
       .setScale(6)
@@ -387,7 +401,7 @@ export class StatStageChangePhase extends PokemonPhase {
    * Format a list of changes into a localised stat-name fragment (e.g. `"Attack, Defense, and Speed"`).
    *
    * @param changes - The changes whose stat names should be listed
-   * @returns The localised fragment, or the generic `"stats"` string for 5+
+   * @returns The localised fragment
    */
   private formatStatsFragment(changes: readonly StatChange[]): string {
     if (changes.length >= 5) {


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
I noticed that the only time the `StatStageChangePhase` modified the underlying objects it was passed was a single call that could be emulated with `Array#map`. This eliminates the need for a deep copy.

## What are the changes from a developer perspective?
Made the above changes.

Used destructuring for object params in certain places, and used a tag type instead of constructor to check for octolock

Added missing doc comments.
## Screenshots/Videos
N/A
## How to test the changes?
Run tests.
## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
