### PR TITLE
fix: only neutral natures are usable in Fresh Start

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -900,14 +900,8 @@ export class FreshStartChallenge extends Challenge {
     // Remove cost reduction
     starterDataEntry.valueReduction = 0;
 
-    // Remove natures except for the default ones
-    const neutralNaturesAttr =
-      (1 << (Nature.HARDY + 1))
-      | (1 << (Nature.DOCILE + 1))
-      | (1 << (Nature.SERIOUS + 1))
-      | (1 << (Nature.BASHFUL + 1))
-      | (1 << (Nature.QUIRKY + 1));
-    dexEntry.natureAttr &= neutralNaturesAttr;
+    // Always start with neutral nature
+    dexEntry.natureAttr = Nature.HARDY;
 
     // Cap all ivs at 15
     for (let i = 0; i < 6; i++) {

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -900,8 +900,14 @@ export class FreshStartChallenge extends Challenge {
     // Remove cost reduction
     starterDataEntry.valueReduction = 0;
 
-    // Always start with neutral nature
-    dexEntry.natureAttr = Nature.HARDY;
+    // Remove natures except for the default ones
+    const neutralNaturesAttr =
+      (1 << (Nature.HARDY + 1))
+      | (1 << (Nature.DOCILE + 1))
+      | (1 << (Nature.SERIOUS + 1))
+      | (1 << (Nature.BASHFUL + 1))
+      | (1 << (Nature.QUIRKY + 1));
+    dexEntry.natureAttr &= neutralNaturesAttr;
 
     // Cap all ivs at 15
     for (let i = 0; i < 6; i++) {

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -60,6 +60,7 @@ import type {
   SeenDialogues,
   SessionSaveData,
   StarterData,
+  StarterDataEntry,
   SystemSaveData,
   TutorialFlags,
   Unlocks,
@@ -70,7 +71,7 @@ import type { StarterSpeciesId } from "#types/starter-species-id";
 import { RUN_HISTORY_LIMIT } from "#ui/run-history-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
 import { fixedInt, NumberHolder, randInt, randSeedItem } from "#utils/common";
-import { decrypt, encrypt, getDataTypeKey, isValidJSON } from "#utils/data";
+import { decrypt, deepCopy, encrypt, getDataTypeKey, isValidJSON } from "#utils/data";
 import { getEnumKeys } from "#utils/enums";
 import { compareVersions } from "#utils/migrator-utils";
 import { toCamelCase } from "#utils/strings";
@@ -1997,6 +1998,8 @@ export class GameData {
 
   getSpeciesDefaultNature(speciesId: StarterSpeciesId): Nature {
     const dexEntry = this.dexData[speciesId];
+    const starterDataEntry: StarterDataEntry = deepCopy(globalScene.gameData.starterData[speciesId]);
+    applyChallenges(ChallengeType.STARTER_SELECT_MODIFY, speciesId, dexEntry, starterDataEntry);
     for (let n = 0; n < 25; n++) {
       if (dexEntry.natureAttr & (1 << (n + 1))) {
         return n as Nature;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -60,7 +60,6 @@ import type {
   SeenDialogues,
   SessionSaveData,
   StarterData,
-  StarterDataEntry,
   SystemSaveData,
   TutorialFlags,
   Unlocks,
@@ -70,7 +69,7 @@ import type {
 import { RUN_HISTORY_LIMIT } from "#ui/run-history-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
 import { fixedInt, NumberHolder, randInt, randSeedItem } from "#utils/common";
-import { decrypt, deepCopy, encrypt, getDataTypeKey, isValidJSON } from "#utils/data";
+import { decrypt, encrypt, getDataTypeKey, isValidJSON } from "#utils/data";
 import { getEnumKeys } from "#utils/enums";
 import { compareVersions } from "#utils/migrator-utils";
 import { toCamelCase } from "#utils/strings";

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -67,7 +67,6 @@ import type {
   VoucherCounts,
   VoucherUnlocks,
 } from "#types/save-data";
-import type { StarterSpeciesId } from "#types/starter-species-id";
 import { RUN_HISTORY_LIMIT } from "#ui/run-history-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
 import { fixedInt, NumberHolder, randInt, randSeedItem } from "#utils/common";
@@ -1979,12 +1978,6 @@ export class GameData {
     };
   }
 
-  getStarterDefaultAbilityIndex(starterId: StarterSpeciesId, abilityAttr?: number): number {
-    abilityAttr ??= this.starterData[starterId].abilityAttr;
-    const species = speciesDataRegistry.getSpecies(starterId);
-    return abilityAttr & AbilityAttr.ABILITY_1 ? 0 : !species.ability2 || abilityAttr & AbilityAttr.ABILITY_2 ? 1 : 2;
-  }
-
   /**
    * Checks whether a species has a specified ability index unlocked for its starter
    * @param species - The species to check
@@ -1994,18 +1987,6 @@ export class GameData {
   public checkStarterAbilityIndexUnlocked(species: PokemonSpecies, abilityIndex: number): boolean {
     const abilityAttr = this.starterData[species.getRootSpeciesId(true)].abilityAttr;
     return !!(abilityAttr & (1 << abilityIndex));
-  }
-
-  getSpeciesDefaultNature(speciesId: StarterSpeciesId): Nature {
-    const dexEntry = this.dexData[speciesId];
-    const starterDataEntry: StarterDataEntry = deepCopy(globalScene.gameData.starterData[speciesId]);
-    applyChallenges(ChallengeType.STARTER_SELECT_MODIFY, speciesId, dexEntry, starterDataEntry);
-    for (let n = 0; n < 25; n++) {
-      if (dexEntry.natureAttr & (1 << (n + 1))) {
-        return n as Nature;
-      }
-    }
-    return 0 as Nature;
   }
 
   getDexAttrLuck(dexAttr: bigint): number {

--- a/src/ui/utils/starter-select-ui-utils.ts
+++ b/src/ui/utils/starter-select-ui-utils.ts
@@ -396,7 +396,7 @@ function getStarterDefaultAbilityIndex(starterId: StarterSpeciesId): number {
   return abilityAttr & AbilityAttr.ABILITY_1 ? 0 : !species.ability2 || abilityAttr & AbilityAttr.ABILITY_2 ? 1 : 2;
 }
 
-function getSpeciesDefaultNature(starterId: StarterSpeciesId): Nature {
+function getStarterDefaultNature(starterId: StarterSpeciesId): Nature {
   const { dexEntry } = getStarterData(starterId);
   for (let n = 0; n < 25; n++) {
     if (dexEntry.natureAttr & (1 << (n + 1))) {
@@ -421,7 +421,7 @@ export function getStarterDetailsFromPreferences(
   const { female, formIndex, shiny, variant } = getStarterDexAttrPropsFromPreferences(starterId, starterPreferences);
   const species = speciesDataRegistry.getSpecies(starterId);
   const abilityIndex = starterPreferences.abilityIndex ?? getStarterDefaultAbilityIndex(starterId);
-  const natureIndex = starterPreferences.nature ?? getSpeciesDefaultNature(starterId);
+  const natureIndex = starterPreferences.nature ?? getStarterDefaultNature(starterId);
   const teraType = starterPreferences.tera ?? species.type1;
 
   return { shiny, formIndex, female, variant, abilityIndex, natureIndex, teraType } satisfies DefinedSpeciesDetails;

--- a/src/ui/utils/starter-select-ui-utils.ts
+++ b/src/ui/utils/starter-select-ui-utils.ts
@@ -9,6 +9,7 @@ import {
   getStarterValueFriendshipCap,
   getValueReductionCandyCounts,
 } from "#balance/starters";
+import { AbilityAttr } from "#enums/ability-attr";
 import { CandyUpgradeDisplayMode } from "#enums/candy-upgrade-display-mode";
 import { CandyUpgradeNotificationMode } from "#enums/candy-upgrade-notification-mode";
 import { ChallengeType } from "#enums/challenge-type";
@@ -16,6 +17,7 @@ import { Challenges } from "#enums/challenges";
 import { DexAttr } from "#enums/dex-attr";
 import { GameModes } from "#enums/game-modes";
 import type { MoveId } from "#enums/move-id";
+import type { Nature } from "#enums/nature";
 import { Passive } from "#enums/passive";
 import { RibbonData } from "#system/ribbon-data";
 import type { DexEntry } from "#types/dex-data";
@@ -387,6 +389,23 @@ export function getStarterDexAttrPropsFromPreferences(
   };
 }
 
+function getStarterDefaultAbilityIndex(starterId: StarterSpeciesId): number {
+  const { starterDataEntry: starterData } = getStarterData(starterId);
+  const abilityAttr = starterData.abilityAttr;
+  const species = speciesDataRegistry.getSpecies(starterId);
+  return abilityAttr & AbilityAttr.ABILITY_1 ? 0 : !species.ability2 || abilityAttr & AbilityAttr.ABILITY_2 ? 1 : 2;
+}
+
+function getSpeciesDefaultNature(starterId: StarterSpeciesId): Nature {
+  const { dexEntry } = getStarterData(starterId);
+  for (let n = 0; n < 25; n++) {
+    if (dexEntry.natureAttr & (1 << (n + 1))) {
+      return n as Nature;
+    }
+  }
+  return 0 as Nature;
+}
+
 /**
  * Convert starter preferences to {@linkcode SpeciesDetails} format.
  *
@@ -401,8 +420,8 @@ export function getStarterDetailsFromPreferences(
 ) {
   const { female, formIndex, shiny, variant } = getStarterDexAttrPropsFromPreferences(starterId, starterPreferences);
   const species = speciesDataRegistry.getSpecies(starterId);
-  const abilityIndex = starterPreferences.abilityIndex ?? globalScene.gameData.getStarterDefaultAbilityIndex(starterId);
-  const natureIndex = starterPreferences.nature ?? globalScene.gameData.getSpeciesDefaultNature(starterId);
+  const abilityIndex = starterPreferences.abilityIndex ?? getStarterDefaultAbilityIndex(starterId);
+  const natureIndex = starterPreferences.nature ?? getSpeciesDefaultNature(starterId);
   const teraType = starterPreferences.tera ?? species.type1;
 
   return { shiny, formIndex, female, variant, abilityIndex, natureIndex, teraType } satisfies DefinedSpeciesDetails;

--- a/src/ui/utils/starter-select-ui-utils.ts
+++ b/src/ui/utils/starter-select-ui-utils.ts
@@ -17,7 +17,7 @@ import { Challenges } from "#enums/challenges";
 import { DexAttr } from "#enums/dex-attr";
 import { GameModes } from "#enums/game-modes";
 import type { MoveId } from "#enums/move-id";
-import type { Nature } from "#enums/nature";
+import { Nature } from "#enums/nature";
 import { Passive } from "#enums/passive";
 import { RibbonData } from "#system/ribbon-data";
 import type { DexEntry } from "#types/dex-data";
@@ -403,7 +403,7 @@ function getStarterDefaultNature(starterId: StarterSpeciesId): Nature {
       return n as Nature;
     }
   }
-  return 0 as Nature;
+  return Nature.HARDY;
 }
 
 /**

--- a/src/ui/utils/starter-select-ui-utils.ts
+++ b/src/ui/utils/starter-select-ui-utils.ts
@@ -393,7 +393,14 @@ function getStarterDefaultAbilityIndex(starterId: StarterSpeciesId): number {
   const { starterDataEntry: starterData } = getStarterData(starterId);
   const abilityAttr = starterData.abilityAttr;
   const species = speciesDataRegistry.getSpecies(starterId);
-  return abilityAttr & AbilityAttr.ABILITY_1 ? 0 : !species.ability2 || abilityAttr & AbilityAttr.ABILITY_2 ? 1 : 2;
+
+  if (abilityAttr & AbilityAttr.ABILITY_1) {
+    return 0;
+  }
+  if (!species.ability2 || abilityAttr & AbilityAttr.ABILITY_2) {
+    return 1;
+  }
+  return 2;
 }
 
 function getStarterDefaultNature(starterId: StarterSpeciesId): Nature {


### PR DESCRIPTION
## What are the changes the user will see?

Fresh start will again start with one of the default natures (Hardy if no default natures are unlocked for that species).

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

[Discord bug report](https://discord.com/channels/1125469663833370665/1329944702874816522/1547242894606471179)

## What are the changes from a developer perspective?

The functions to get the default ability and nature for a given starters now use `getStarterData(starterId)`, ensuring that the Fresh Start challenge is applied. Since these functions were only called once anyway, I moved them to the `starter-select-ui-utils.ts` file.

## Screenshots/Videos
<details><summary>Before</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/25f9ec09-12e7-4840-a7db-66bf2506251f" />

</details>
<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/916c1485-0ac9-4768-a22e-b875e019ee37" />

</details>


## How to test the changes?

Start a fresh start challenge and check the nature in the summary bottom left.

To reproduce on beta, you need a pokemon where the first nature isn't neutral

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)