### PR TITLE
dev: remove unnecessary error message for empty session slots

### DIFF
--- a/src/api/api-base.ts
+++ b/src/api/api-base.ts
@@ -98,11 +98,12 @@ export abstract class ApiBase {
   }
 
   /**
-   * Helper to transform data to {@linkcode URLSearchParams}
-   * Any key with a value of `undefined` will be ignored.
+   * Helper to transform data to `URLSearchParams`.
+   *
+   * Any key with a value of `undefined` or `""` will be ignored. \
    * Any key with a value of `null` will be included.
-   * @param data the data to transform to {@linkcode URLSearchParams}
-   * @returns a {@linkcode URLSearchParams} representaton of {@linkcode data}
+   * @param data - The data to transform
+   * @returns A {@linkcode URLSearchParams} representaton of the input
    */
   protected toUrlSearchParams(data: Record<string, any>): URLSearchParams {
     const arr = Object.entries(data)

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -782,30 +782,28 @@ export class GameData {
     } as SessionSaveData;
   }
 
-  async getSession(slotId: number): Promise<SessionSaveData | undefined> {
+  public async getSession(slotId: number): Promise<SessionSaveData | undefined> {
     // TODO: Do we need this fallback anymore?
     if (slotId < 0) {
       return;
     }
 
-    console.log("Getting Session Slot id: %d", slotId);
+    console.debug("Getting Session Slot id: %d", slotId);
 
-    // Check local storage for the cached session data
-    if (bypassLogin || localStorage.getItem(getSessionDataLocalStorageKey(slotId))) {
-      const sessionData = localStorage.getItem(getSessionDataLocalStorageKey(slotId));
-      if (!sessionData) {
-        console.error("No session data found!");
-        return;
-      }
+    const sessionData = localStorage.getItem(getSessionDataLocalStorageKey(slotId));
+    if (sessionData) {
       return this.parseSessionData(decrypt(sessionData, bypassLogin));
     }
+    if (bypassLogin) {
+      return;
+    }
 
-    // Ask the server API for the save data and store it in localstorage
     const response = await pokerogueApi.savedata.session.get({ slot: slotId, clientSessionId });
-
-    // TODO: This is a far cry from proper JSON validation
-    if (response == null || response.length === 0 || response.charAt(0) !== "{") {
-      console.error("Invalid save data JSON detected!", response);
+    if (response == null || response.trim() === "save does not exist") {
+      return;
+    }
+    if (!isValidJSON(response)) {
+      console.error("Invalid save data detected!", response);
       return;
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Reducing console spam when developing/testing.

## What are the changes from a developer perspective?
- Removed an unnecessary `console.error` that was emitted when a session save slot was empty (which is a valid state, not an error).
- Changed a `console.log` to `.debug`.
- Resolved the nearby todo by using `isValidJSON()` instead of the custom, inadequate JSON validation check.

## How to test the changes?
Open the "Load Game" menu locally while one or more slots are empty while the devtools console is open.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually