### PR TITLE
fix(ui): fix word wrap value in `PokedexInfoOverlay#desc`

### DIFF
--- a/src/ui/containers/pokedex-info-overlay.ts
+++ b/src/ui/containers/pokedex-info-overlay.ts
@@ -51,7 +51,7 @@ export class PokedexInfoOverlay extends Phaser.GameObjects.Container implements 
 
     // set up the description; wordWrap uses true pixels, unaffected by any scaling, while other values are affected
     this.desc = addTextObject(BORDER, BORDER - 2, "", TextStyle.BATTLE_INFO, {
-      wordWrap: { width: (this.width - (BORDER - 2) * 2) * GLOBAL_SCALE },
+      wordWrap: { width: (this.width - (BORDER - 1) * 2) * GLOBAL_SCALE },
     });
 
     // limit the text rendering, required for scrolling later on


### PR DESCRIPTION
## What are the changes the user will see?
Text won't be cut off any more in the description box in the Pokédex.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Changed the word wrap value of the `PokdexInfoOverlay#desc` text object.

## Screenshots/Videos
<details><summary>Before</summary>

<img width="1231" height="692" alt="image" src="https://github.com/user-attachments/assets/26dcceff-112c-4a0b-962c-7ec5ade2864e" />

</details>
<details><summary>After</summary>

<img width="1236" height="692" alt="image" src="https://github.com/user-attachments/assets/6c0f814b-49b6-4d35-a90b-e930b76bd23e" />

</details>

## How to test the changes?
Look at the descriptions of various things in the Pokédex.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
- [x] I have provided screenshots/videos of the changes (if applicable)