### PR TITLE
misc: the title stats timer will be cleared when logging out

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -294,6 +294,8 @@ export class BattleScene extends SceneBase {
   public readonly animations: Animation = new Animation();
   declare renderer: Phaser.Renderer.WebGL.WebGLRenderer;
 
+  public titleStatsTimer: NodeJS.Timeout | null = null;
+
   constructor() {
     super("battle");
 

--- a/src/ui/handlers/menu-ui-handler.ts
+++ b/src/ui/handlers/menu-ui-handler.ts
@@ -705,10 +705,13 @@ export class MenuUiHandler extends MessageUiHandler {
           const doLogout = () => {
             ui.setMode(UiMode.LOADING, {
               buttonActions: [],
-              fadeOut: () =>
-                pokerogueApi.account.logout().then(() => {
-                  updateUserInfo().then(() => globalScene.reset(true, true));
-                }),
+              fadeOut: async () => {
+                await pokerogueApi.account.logout();
+                await updateUserInfo();
+                globalScene.titleStatsTimer && clearInterval(globalScene.titleStatsTimer);
+                globalScene.titleStatsTimer = null;
+                globalScene.reset(true, true);
+              },
             });
           };
           if (globalScene.currentBattle) {

--- a/src/ui/handlers/title-ui-handler.ts
+++ b/src/ui/handlers/title-ui-handler.ts
@@ -34,8 +34,6 @@ export class TitleUiHandler extends OptionSelectUiHandler {
 
   private splashMessage: string;
 
-  private titleStatsTimer: NodeJS.Timeout | null;
-
   constructor() {
     super(UiMode.TITLE);
   }
@@ -213,9 +211,7 @@ export class TitleUiHandler extends OptionSelectUiHandler {
 
     this.updateTitleStats();
 
-    this.titleStatsTimer = setInterval(() => {
-      this.updateTitleStats();
-    }, 60000);
+    globalScene.titleStatsTimer = setInterval(() => this.updateTitleStats(), 60000);
 
     globalScene.tweens.add({
       targets: [this.titleContainer, ui.getMessageHandler().bg],
@@ -236,8 +232,8 @@ export class TitleUiHandler extends OptionSelectUiHandler {
 
     this.eventDisplay?.clear();
 
-    this.titleStatsTimer && clearInterval(this.titleStatsTimer);
-    this.titleStatsTimer = null;
+    globalScene.titleStatsTimer && clearInterval(globalScene.titleStatsTimer);
+    globalScene.titleStatsTimer = null;
 
     globalScene.tweens.add({
       targets: [this.titleContainer, ui.getMessageHandler().bg],


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

(Unless they look in the browser devtools console after logging out).

## Why am I making these changes?
Preventing console spam.

## What are the changes from a developer perspective?
Moved the timer that refreshes the title stats from `TitleUiHandler` to `BattleScene` so that it can be cleared from the log out handler in `MenuUiHandler`.

## Screenshots/Videos
<details><summary>Console on main</summary>

<img width="2552" height="1011" alt="image" src="https://github.com/user-attachments/assets/3db3d035-e0d5-4323-88ac-5501a1217b2d" />

</details>

## How to test the changes?
Connect to rogueserver locally, then log in and log back out. There should be no errors in the console or further API calls to check the title stats. You can reduce the timer interval from 60s on line 214 of `title-ui-handler.ts` to make it more obvious.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
- [x] I have provided screenshots/videos of the changes (if applicable)