### PR TITLE
misc: abort build process if static shell plugin fails

### DIFF
--- a/plugins/vite/static-shell-plugin.ts
+++ b/plugins/vite/static-shell-plugin.ts
@@ -100,7 +100,7 @@ interface AssetManifest {
 function resolveAssetManifest(
   manifest: Record<string, ManifestEntry>,
   entry: ManifestEntry,
-  warn: (message: string) => void,
+  error: (message: string) => void,
 ): AssetManifest {
   const cssFiles = new Set<string>(entry.css ?? []);
   const preloadFiles: string[] = [];
@@ -108,8 +108,8 @@ function resolveAssetManifest(
   for (const importKey of entry.imports ?? []) {
     const chunk = manifest[importKey];
     if (!chunk) {
-      warn(`"${importKey}" referenced by entry imports but missing from manifest.`);
-      continue;
+      error(`"${importKey}" referenced by entry imports but missing from manifest.`);
+      throw new Error("Aborting build process!");
     }
     preloadFiles.push(chunk.file);
     for (const css of chunk.css ?? []) {
@@ -134,7 +134,7 @@ function resolveAssetManifest(
  */
 export function staticShellPlugin(): VitePlugin {
   let logger: Logger;
-  const { cyan, gray, green, yellow } = chalk;
+  const { cyan, gray, green, red } = chalk;
 
   return {
     name: NAME,
@@ -146,7 +146,7 @@ export function staticShellPlugin(): VitePlugin {
     },
     closeBundle(): void {
       const logSuffix = gray(` [${NAME}]`);
-      const warn = (message: string) => logger.warn(yellow(`${message}${logSuffix}`));
+      const error = (message: string) => logger.error(red(`${message}${logSuffix}`));
       logger.info(cyan(`\t→ Plugin: ${NAME} v${VERSION}`));
 
       const outDir = path.resolve("dist");
@@ -154,27 +154,28 @@ export function staticShellPlugin(): VitePlugin {
       const indexPath = path.join(outDir, "index.html");
 
       if (!fs.existsSync(manifestPath) || !fs.existsSync(indexPath)) {
-        warn(`Skipping: expected ${manifestPath} and ${indexPath} to exist.`);
-        return;
+        error(`Expected "${manifestPath}" and "${indexPath}" to exist!`);
+        throw new Error("Aborting build process!");
       }
 
       const manifest: Record<string, ManifestEntry> = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
       const entry = manifest["index.html"];
 
       if (!entry) {
-        warn(`Skipping: no "index.html" entry found in ${manifestPath}.`);
-        return;
+        error(`No "index.html" entry found in "${manifestPath}"!`);
+        throw new Error("Aborting build process!");
       }
 
-      const assetManifest = resolveAssetManifest(manifest, entry, warn);
+      const assetManifest = resolveAssetManifest(manifest, entry, error);
       fs.writeFileSync(path.join(outDir, "asset-manifest.json"), JSON.stringify(assetManifest));
 
       let html = fs.readFileSync(indexPath, "utf-8");
-      const hadEntryScript = ENTRY_SCRIPT_PATTERN.test(html);
+      const allScriptsFound =
+        ENTRY_SCRIPT_PATTERN.test(html) && MODULEPRELOAD_LINK_PATTERN.test(html) && STYLESHEET_LINK_PATTERN.test(html);
 
-      if (!hadEntryScript) {
-        warn(`"${indexPath}" did not contain the expected Vite entry <script> tag - static shell was not applied.`);
-        return;
+      if (!allScriptsFound) {
+        error(`"${indexPath}" did not contain the expected Vite entry <script> tag!`);
+        throw new Error("Aborting build process!");
       }
 
       html = html.replace(ENTRY_SCRIPT_PATTERN, CRITICAL_STYLE + BOOTSTRAP_SCRIPT);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Suggestion by Dean.

## What are the changes from a developer perspective?
The Vite plugin that rewrites `index.html` to prevent caching issues will now abort the build process entirely if the plugin fails for some reason.

## How to test the changes?
`pnpm build`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually